### PR TITLE
Remove the underline

### DIFF
--- a/static/self/css/footer-link.css
+++ b/static/self/css/footer-link.css
@@ -6,7 +6,6 @@
 }
 .footer-link:hover {
   color: #337ab7 !important;
-  text-decoration: underline;
   text-decoration-color: #000;
   text-underline-position: under;
 }


### PR DESCRIPTION
<img width="182" height="44" alt="PixPin_2025-09-13_15-47-25" src="https://github.com/user-attachments/assets/32b9ea62-06e9-48d7-82c9-2edd77a8e19b" />

The position of the underline is strange（？）