### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Auto Deploy with OSS
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Ark-Aak/luogu-saver-next/security/code-scanning/2](https://github.com/Ark-Aak/luogu-saver-next/security/code-scanning/2)

To fix the problem, add an explicit `permissions:` block to the workflow so the `GITHUB_TOKEN` has least-privilege access. Since neither `deploy-frontend` nor `deploy-backend` appears to need any GitHub API write access, we can safely set permissions to `contents: read` at the workflow root (applies to all jobs) or even `permissions: {}` if you are sure no GitHub API access is needed. Using `contents: read` matches CodeQL’s suggested minimal starting point and keeps the workflow flexible for typical actions like `actions/checkout`.

The single best fix with minimal functional impact is to add a workflow-level permissions block right after the `name:` line, before the `on:` section, like:

```yaml
name: Auto Deploy with OSS
permissions:
  contents: read

on:
  ...
```

This does not change any steps, secrets usage, or deployment behavior; it only tightens the implicit `GITHUB_TOKEN` permissions. No additional methods or imports are needed since this is purely a YAML configuration change in `.github/workflows/deploy.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
