### PR TITLE
Potential fix for code scanning alert no. 3: Insecure randomness

### DIFF
--- a/server/src/lib/markdown.ts
+++ b/server/src/lib/markdown.ts
@@ -1,6 +1,7 @@
 import markdownit from "markdown-it";
 import markdownItAttrs from "markdown-it-attrs";
 import markdownItContainer from "markdown-it-container";
+import crypto from "crypto";
 
 let mdPromise: Promise<markdownit> | null = null;
 
@@ -132,7 +133,9 @@ export default async function renderMarkdown(src: string) {
 
     const preprocessed = src.split(/\r?\n/).map(preprocessLine).join("\n");
 
-    const uid = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+    const uid =
+        Date.now().toString(36) +
+        crypto.randomBytes(4).toString("hex").slice(0, 4);
 
     const codePlaceholder = (i: number) => `CODE?PLACEHOLDER${uid}?${i}?`;
     const mathDisplayPlaceholder = (i: number) => `MATH?DISPLAY${uid}?${i}?`;


### PR DESCRIPTION
Potential fix for [https://github.com/Ark-Aak/luogu-saver-next/security/code-scanning/3](https://github.com/Ark-Aak/luogu-saver-next/security/code-scanning/3)

In general, to fix this issue you should replace `Math.random()` (and any entropy derived from it) with a cryptographically secure random source, such as Node’s `crypto.randomBytes` or the Web Crypto API, when generating identifiers that might be used in any security-related or cross-request context.

For this specific code, the safest and least invasive fix is:

- Keep the overall structure (a short unique `uid` string used in placeholders).
- Replace the `Date.now() + Math.random()` approach with a UID built from:
  - A timestamp component (`Date.now().toString(36)`) – fine to keep for readability and weak ordering.
  - A secure random component derived from `crypto.randomBytes`, encoded in base36 or hex and truncated to a similar length as before so that behavior (string size, format) remains close to unchanged.

Implementation details:

- In `server/src/lib/markdown.ts`, add an import from Node’s `crypto` module near the top (since this is server-side code).
- Change line 135 from:

  ```ts
  const uid = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
  ```

  to something like:

  ```ts
  const uid =
      Date.now().toString(36) +
      crypto.randomBytes(4).toString("hex").slice(0, 4);
  ```

  This preserves a short suffix (4 characters) while making it derived from cryptographically secure random bytes. The exact characters differ (hex vs base36), but they remain URL/HTML-safe and simple alphanumerics.

- No further logic needs to change, since `uid` remains a string and is used only by string interpolation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
