### PR TITLE
feat(user): add OI/XCPC award certification badges and user profile page

### DIFF
--- a/packages/backend/src/entities/user.ts
+++ b/packages/backend/src/entities/user.ts
@@ -2,7 +2,7 @@ import { Entity, PrimaryColumn, Column, CreateDateColumn, UpdateDateColumn } fro
 
 import { BaseEntity } from './base';
 
-import { UserColor } from '@/shared/user';
+import { UserColor, UserPrize } from '@/shared/user';
 import { Cacheable } from '@/decorators/cacheable';
 
 @Entity({ name: 'user' })
@@ -15,6 +15,18 @@ export class User extends BaseEntity {
 
     @Column({ type: 'varchar' })
     color: UserColor;
+
+    @Column({ name: 'ccf_level', type: 'int', default: 0 })
+    ccfLevel: number;
+
+    @Column({ name: 'xcpc_level', type: 'int', default: 0 })
+    xcpcLevel: number;
+
+    @Column({ type: 'json', nullable: true })
+    prizes: UserPrize[] | null;
+
+    @Column({ name: 'profile_fetched_at', type: 'datetime', nullable: true })
+    profileFetchedAt: Date | null;
 
     @CreateDateColumn({ name: 'created_at' })
     createdAt: number;

--- a/packages/backend/src/entities/user.ts
+++ b/packages/backend/src/entities/user.ts
@@ -22,6 +22,15 @@ export class User extends BaseEntity {
     @Column({ name: 'xcpc_level', type: 'int', default: 0 })
     xcpcLevel: number;
 
+    @Column({ type: 'text', nullable: true })
+    slogan: string | null;
+
+    @Column({ type: 'text', nullable: true })
+    introduction: string | null;
+
+    @Column({ name: 'rendered_introduction', type: 'text', nullable: true })
+    renderedIntroduction: string | null;
+
     @Column({ type: 'json', nullable: true })
     prizes: UserPrize[] | null;
 

--- a/packages/backend/src/routers/index.ts
+++ b/packages/backend/src/routers/index.ts
@@ -7,6 +7,7 @@ import workflowRouter from './workflow.router';
 import censorshipRouter from './censorship.router';
 import tokenRouter from './token.router';
 import authRouter from './auth.router';
+import userRouter from './user.router';
 import { DefaultState, Context } from 'koa';
 
 const router = new Router<DefaultState, Context>();
@@ -19,5 +20,6 @@ router.use(workflowRouter.routes(), workflowRouter.allowedMethods());
 router.use(censorshipRouter.routes(), censorshipRouter.allowedMethods());
 router.use(tokenRouter.routes(), tokenRouter.allowedMethods());
 router.use(authRouter.routes(), authRouter.allowedMethods());
+router.use(userRouter.routes(), userRouter.allowedMethods());
 
 export default router;

--- a/packages/backend/src/routers/user.router.ts
+++ b/packages/backend/src/routers/user.router.ts
@@ -52,6 +52,8 @@ router.get('/:id', async (ctx: Context) => {
             color: user.color,
             ccfLevel: user.ccfLevel,
             xcpcLevel: user.xcpcLevel,
+            slogan: user.slogan,
+            renderedIntroduction: user.renderedIntroduction,
             prizes: user.prizes,
             profileFetchedAt: user.profileFetchedAt,
             profileStale: stale,

--- a/packages/backend/src/routers/user.router.ts
+++ b/packages/backend/src/routers/user.router.ts
@@ -1,0 +1,81 @@
+import Router from 'koa-router';
+import { Context, DefaultState } from 'koa';
+import { UserService } from '@/services/user.service';
+import { TaskService } from '@/services/task.service';
+import { TaskType, SaveTarget } from '@/shared/task';
+import { logger } from '@/lib/logger';
+
+const router = new Router<DefaultState, Context>({ prefix: '/user' });
+
+function parseUid(raw: string): number | null {
+    if (!/^[1-9]\d*$/.test(raw)) return null;
+    const uid = Number(raw);
+    if (!Number.isInteger(uid) || uid <= 0) return null;
+    return uid;
+}
+
+async function dispatchProfileRefresh(uid: number): Promise<string | null> {
+    try {
+        const task = await TaskService.createTask(TaskType.SAVE, {
+            target: SaveTarget.PROFILE,
+            targetId: String(uid),
+            metadata: {}
+        });
+        await TaskService.dispatchTask(task.id);
+        return task.id;
+    } catch (error) {
+        logger.error({ error, uid }, 'Failed to dispatch profile refresh task');
+        return null;
+    }
+}
+
+router.get('/:id', async (ctx: Context) => {
+    const uid = parseUid(ctx.params.id);
+    if (uid === null) {
+        ctx.fail(400, 'Invalid user ID');
+        return;
+    }
+    try {
+        const user = await UserService.getUserById(uid);
+        if (!user) {
+            ctx.fail(404, 'User not found');
+            return;
+        }
+        const stale = UserService.isProfileStale(user);
+        if (stale) {
+            // fire-and-forget; response should not wait
+            void dispatchProfileRefresh(uid);
+        }
+        ctx.success({
+            id: user.id,
+            name: user.name,
+            color: user.color,
+            ccfLevel: user.ccfLevel,
+            xcpcLevel: user.xcpcLevel,
+            prizes: user.prizes,
+            profileFetchedAt: user.profileFetchedAt,
+            profileStale: stale,
+            createdAt: user.createdAt,
+            updatedAt: user.updatedAt
+        });
+    } catch (error) {
+        logger.error({ error, uid }, 'Failed to retrieve user');
+        ctx.fail(500, 'Failed to retrieve user');
+    }
+});
+
+router.post('/:id/refresh', async (ctx: Context) => {
+    const uid = parseUid(ctx.params.id);
+    if (uid === null) {
+        ctx.fail(400, 'Invalid user ID');
+        return;
+    }
+    const taskId = await dispatchProfileRefresh(uid);
+    if (!taskId) {
+        ctx.fail(500, 'Failed to dispatch profile refresh');
+        return;
+    }
+    ctx.success({ taskId });
+});
+
+export default router;

--- a/packages/backend/src/services/user.service.ts
+++ b/packages/backend/src/services/user.service.ts
@@ -8,6 +8,16 @@ import {
     getServiceRepository,
     saveServiceEntity
 } from '@/services/helpers/repository.helper';
+import { PROFILE_TTL_MS, UserColor, UserPrize } from '@/shared/user';
+
+export interface SaveLuoguUserProfileInput {
+    uid: number;
+    name: string;
+    color: UserColor;
+    ccfLevel: number;
+    xcpcLevel: number;
+    prizes: UserPrize[];
+}
 
 export class UserService {
     /*
@@ -44,6 +54,13 @@ export class UserService {
         return createServiceEntity<User>(User, data, manager);
     }
 
+    /*
+     * Upsert from the inline content path (article / paste authors).
+     *
+     * Only writes identity + dynamic-level fields, never `prizes` or `profile_fetched_at`.
+     * This is what preserves richer profile data between inline upserts and the dedicated
+     * `save:profile` task; see `spec/user-system.spec.md` Section 3.
+     */
     @CacheEvict((data: Partial<User>) => (data.id === undefined ? [] : `user:${data.id}`))
     static async upsertLuoguUser(data: Partial<User>, manager?: EntityManager): Promise<User> {
         if (data.id === undefined) {
@@ -51,8 +68,55 @@ export class UserService {
         }
 
         const repository = getServiceRepository<User>(User, manager);
-        const user = repository.create(data);
-        await repository.upsert(user, ['id']);
+        const restricted: Partial<User> = {
+            id: data.id,
+            name: data.name,
+            color: data.color,
+            ccfLevel: data.ccfLevel ?? 0,
+            xcpcLevel: data.xcpcLevel ?? 0
+        };
+        const user = repository.create(restricted);
+        await repository.upsert(user, {
+            conflictPaths: ['id'],
+            skipUpdateIfNoValuesChanged: true
+        });
         return user;
+    }
+
+    /*
+     * Profile-task write path. Authoritative for the moment: bumps `profile_fetched_at`
+     * and replaces the `prizes` array wholesale. See `spec/user-system.spec.md` Section 4.4.
+     */
+    @CacheEvict((input: SaveLuoguUserProfileInput) => `user:${input.uid}`)
+    static async saveLuoguUserProfile(
+        input: SaveLuoguUserProfileInput,
+        manager?: EntityManager
+    ): Promise<User> {
+        const repository = getServiceRepository<User>(User, manager);
+        const user = repository.create({
+            id: input.uid,
+            name: input.name,
+            color: input.color,
+            ccfLevel: input.ccfLevel,
+            xcpcLevel: input.xcpcLevel,
+            prizes: input.prizes,
+            profileFetchedAt: new Date()
+        });
+        await repository.upsert(user, {
+            conflictPaths: ['id'],
+            skipUpdateIfNoValuesChanged: false
+        });
+        return user;
+    }
+
+    static isProfileStale(user: User | null): boolean {
+        if (!user) return true;
+        if (user.prizes === null || user.prizes === undefined) return true;
+        if (!user.profileFetchedAt) return true;
+        const fetchedAt =
+            user.profileFetchedAt instanceof Date
+                ? user.profileFetchedAt.getTime()
+                : new Date(user.profileFetchedAt).getTime();
+        return Date.now() - fetchedAt > PROFILE_TTL_MS;
     }
 }

--- a/packages/backend/src/services/user.service.ts
+++ b/packages/backend/src/services/user.service.ts
@@ -16,6 +16,9 @@ export interface SaveLuoguUserProfileInput {
     color: UserColor;
     ccfLevel: number;
     xcpcLevel: number;
+    slogan: string | null;
+    introduction: string | null;
+    renderedIntroduction: string | null;
     prizes: UserPrize[];
 }
 
@@ -99,6 +102,9 @@ export class UserService {
             color: input.color,
             ccfLevel: input.ccfLevel,
             xcpcLevel: input.xcpcLevel,
+            slogan: input.slogan,
+            introduction: input.introduction,
+            renderedIntroduction: input.renderedIntroduction,
             prizes: input.prizes,
             profileFetchedAt: new Date()
         });

--- a/packages/backend/src/shared/user.ts
+++ b/packages/backend/src/shared/user.ts
@@ -7,3 +7,11 @@ export enum UserColor {
     PURPLE = 'Purple',
     CHEATER = 'Cheater'
 }
+
+export interface UserPrize {
+    year: number;
+    contestName: string;
+    prize: string;
+}
+
+export const PROFILE_TTL_MS = 24 * 60 * 60 * 1000;

--- a/packages/backend/src/shared/user.ts
+++ b/packages/backend/src/shared/user.ts
@@ -10,8 +10,11 @@ export enum UserColor {
 
 export interface UserPrize {
     year: number;
-    contestName: string;
+    contest: string;
+    event: string | null;
     prize: string;
+    score?: number;
+    rank?: number;
 }
 
 export const PROFILE_TTL_MS = 24 * 60 * 60 * 1000;

--- a/packages/backend/src/types/luogu-api.d.ts
+++ b/packages/backend/src/types/luogu-api.d.ts
@@ -523,8 +523,17 @@ export interface PostData {
     canDelete: boolean;
 }
 
+export interface LuoguPrize {
+    year: number;
+    contest: string;
+    event: string | null;
+    prize: string;
+    score?: number;
+    rank?: number;
+}
+
 export interface UserData {
-    prizes: []; // TODO
+    prizes: { prize: LuoguPrize }[];
     gu: GuRating;
     elo: (EloRating & { previous: EloRating | null })[];
     dailyCounts: Record<string, [number, number]>;

--- a/packages/backend/src/utils/luogu-api.ts
+++ b/packages/backend/src/utils/luogu-api.ts
@@ -6,6 +6,8 @@ export function buildUser(user: UserSummary): Partial<User> {
     return {
         id: user.uid,
         name: user.name,
-        color: user.color as UserColor
+        color: user.color as UserColor,
+        ccfLevel: user.ccfLevel ?? 0,
+        xcpcLevel: user.xcpcLevel ?? 0
     };
 }

--- a/packages/backend/src/workers/handlers/task/save/profile.handler.ts
+++ b/packages/backend/src/workers/handlers/task/save/profile.handler.ts
@@ -9,6 +9,7 @@ import { logger } from '@/lib/logger';
 import { emitToRoom } from '@/lib/socket';
 import { TaskHandler, TaskTextResult, WorkflowResult } from '@/workers/types';
 import { UserColor, UserPrize } from '@/shared/user';
+import renderMarkdown from '@/lib/markdown';
 
 export class ProfileHandler implements TaskHandler<SaveTask> {
     public taskType = 'save:profile';
@@ -30,17 +31,43 @@ export class ProfileHandler implements TaskHandler<SaveTask> {
             throw new UnrecoverableError(`Profile response shape invalid for uid=${uid}`);
         }
 
-        const rawPrizes = (userData as { prize?: unknown }).prize;
+        // Luogu user-page response shape (verified against live luogu.com.cn 2026-05):
+        //   resp.data.prizes : Array<{ prize: { year, contest, event, prize, score?, rank? } }>
+        // Each entry is wrapped in a one-level `prize` object that we must unwrap.
+        // The `resp.data.user.prize` field, despite its name, is unrelated and may be empty.
+        const rawPrizes = (resp.data as { prizes?: unknown }).prizes;
         const prizes: UserPrize[] = Array.isArray(rawPrizes)
-            ? (rawPrizes as UserPrize[]).filter(
-                  p =>
-                      p &&
-                      typeof p === 'object' &&
-                      typeof (p as UserPrize).year === 'number' &&
-                      typeof (p as UserPrize).contestName === 'string' &&
-                      typeof (p as UserPrize).prize === 'string'
-              )
+            ? rawPrizes
+                  .map(entry => {
+                      const inner =
+                          entry && typeof entry === 'object'
+                              ? ((entry as { prize?: unknown }).prize ?? entry)
+                              : null;
+                      return inner;
+                  })
+                  .filter(
+                      (p): p is UserPrize =>
+                          !!p &&
+                          typeof p === 'object' &&
+                          typeof (p as UserPrize).year === 'number' &&
+                          typeof (p as UserPrize).contest === 'string' &&
+                          typeof (p as UserPrize).prize === 'string'
+                  )
+                  .map(p => ({
+                      year: p.year,
+                      contest: p.contest,
+                      event: typeof p.event === 'string' ? p.event : null,
+                      prize: p.prize,
+                      ...(typeof p.score === 'number' ? { score: p.score } : {}),
+                      ...(typeof p.rank === 'number' ? { rank: p.rank } : {})
+                  }))
             : [];
+
+        const rawSlogan = (userData as { slogan?: unknown }).slogan;
+        const slogan = typeof rawSlogan === 'string' && rawSlogan.length > 0 ? rawSlogan : null;
+        const rawIntro = (userData as { introduction?: unknown }).introduction;
+        const introduction = typeof rawIntro === 'string' && rawIntro.length > 0 ? rawIntro : null;
+        const renderedIntroduction = introduction ? await renderMarkdown(introduction) : null;
 
         await UserService.saveLuoguUserProfile({
             uid: userData.uid,
@@ -48,6 +75,9 @@ export class ProfileHandler implements TaskHandler<SaveTask> {
             color: userData.color as UserColor,
             ccfLevel: userData.ccfLevel ?? 0,
             xcpcLevel: userData.xcpcLevel ?? 0,
+            slogan,
+            introduction,
+            renderedIntroduction,
             prizes
         });
 

--- a/packages/backend/src/workers/handlers/task/save/profile.handler.ts
+++ b/packages/backend/src/workers/handlers/task/save/profile.handler.ts
@@ -1,0 +1,64 @@
+import { UnrecoverableError } from 'bullmq';
+
+import type { SaveTask } from '@/shared/task';
+import { fetch } from '@/utils/fetch';
+import { C3vkMode } from '@/shared/c3vk';
+import type { LentilleDataResponse, UserData } from '@/types/luogu-api';
+import { UserService } from '@/services/user.service';
+import { logger } from '@/lib/logger';
+import { emitToRoom } from '@/lib/socket';
+import { TaskHandler, TaskTextResult, WorkflowResult } from '@/workers/types';
+import { UserColor, UserPrize } from '@/shared/user';
+
+export class ProfileHandler implements TaskHandler<SaveTask> {
+    public taskType = 'save:profile';
+
+    public async handle(task: SaveTask): Promise<WorkflowResult<TaskTextResult>> {
+        const rawTargetId = task.payload.targetId;
+        if (typeof rawTargetId !== 'string' || !/^[1-9]\d*$/.test(rawTargetId)) {
+            throw new UnrecoverableError(
+                `Invalid profile targetId: ${JSON.stringify(rawTargetId)}`
+            );
+        }
+        const uid = Number(rawTargetId);
+
+        const url = `https://www.luogu.com/user/${uid}`;
+        const resp: LentilleDataResponse<UserData> = await fetch(url, C3vkMode.MODERN);
+
+        const userData = resp?.data?.user;
+        if (!userData || typeof userData !== 'object' || typeof userData.uid !== 'number') {
+            throw new UnrecoverableError(`Profile response shape invalid for uid=${uid}`);
+        }
+
+        const rawPrizes = (userData as { prize?: unknown }).prize;
+        const prizes: UserPrize[] = Array.isArray(rawPrizes)
+            ? (rawPrizes as UserPrize[]).filter(
+                  p =>
+                      p &&
+                      typeof p === 'object' &&
+                      typeof (p as UserPrize).year === 'number' &&
+                      typeof (p as UserPrize).contestName === 'string' &&
+                      typeof (p as UserPrize).prize === 'string'
+              )
+            : [];
+
+        await UserService.saveLuoguUserProfile({
+            uid: userData.uid,
+            name: userData.name,
+            color: userData.color as UserColor,
+            ccfLevel: userData.ccfLevel ?? 0,
+            xcpcLevel: userData.xcpcLevel ?? 0,
+            prizes
+        });
+
+        emitToRoom(`user_${uid}`, `user:${uid}:profile-updated`);
+        logger.info({ uid, prizeCount: prizes.length }, 'Profile saved');
+
+        return {
+            skipNextStep: false,
+            data: {
+                text: ''
+            }
+        };
+    }
+}

--- a/packages/backend/src/workers/index.ts
+++ b/packages/backend/src/workers/index.ts
@@ -8,6 +8,7 @@ import { logger } from '@/lib/logger';
 
 import { ArticleHandler } from '@/workers/handlers/task/save/article.handler';
 import { PasteHandler } from '@/workers/handlers/task/save/paste.handler';
+import { ProfileHandler } from '@/workers/handlers/task/save/profile.handler';
 import { SummaryHandler } from '@/workers/handlers/task/llm/summary.handler';
 import { EmbeddingHandler } from '@/workers/handlers/task/llm/embedding.handler';
 import { ChatHandler } from '@/workers/handlers/task/llm/chat.handler';
@@ -36,6 +37,7 @@ export function bootstrap() {
 
     saveProcessor.registerHandler(new ArticleHandler());
     saveProcessor.registerHandler(new PasteHandler());
+    saveProcessor.registerHandler(new ProfileHandler());
 
     aiProcessor.registerHandler(new SummaryHandler());
     aiProcessor.registerHandler(new EmbeddingHandler());

--- a/packages/frontend/src/api/user.ts
+++ b/packages/frontend/src/api/user.ts
@@ -1,0 +1,13 @@
+import { apiFetch } from '@/utils/request.ts';
+import type { ApiResponse } from '@/types/common';
+import type { UserProfile } from '@/types/user';
+
+export async function getUserProfile(id: number | string) {
+    return (await apiFetch(`/user/${id}`)) as ApiResponse<UserProfile>;
+}
+
+export async function refreshUserProfile(id: number | string) {
+    return (await apiFetch(`/user/${id}/refresh`, {
+        method: 'POST'
+    })) as ApiResponse<{ taskId: string }>;
+}

--- a/packages/frontend/src/components/UserLink.vue
+++ b/packages/frontend/src/components/UserLink.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { NAvatar } from 'naive-ui';
 import type { User } from '@/types/user';
+import UserPrizeBadge from './UserPrizeBadge.vue';
 
 defineProps<{
     user?: User;
@@ -17,14 +18,18 @@ defineProps<{
             :src="`https://cdn.luogu.com.cn/upload/usericon/${user?.id || 3}.png`"
             style="margin-right: 8px"
         />
-        <a
-            :href="`/user/${user?.id}`"
+        <router-link
+            :to="`/user/${user?.id}`"
             class="user-name"
             :class="`user-${user?.color || 'Gray'}`"
-            target="_blank"
         >
             {{ user?.name || '未知用户' }}
-        </a>
+        </router-link>
+        <UserPrizeBadge
+            v-if="user && ((user.ccfLevel ?? 0) > 0 || (user.xcpcLevel ?? 0) > 0)"
+            :ccf-level="user.ccfLevel ?? 0"
+            :xcpc-level="user.xcpcLevel ?? 0"
+        />
     </div>
 </template>
 

--- a/packages/frontend/src/components/UserPrizeBadge.vue
+++ b/packages/frontend/src/components/UserPrizeBadge.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { NTooltip } from 'naive-ui';
+
+const props = withDefaults(
+    defineProps<{
+        ccfLevel?: number;
+        xcpcLevel?: number;
+        size?: number;
+    }>(),
+    {
+        ccfLevel: 0,
+        xcpcLevel: 0,
+        size: 20
+    }
+);
+
+// OI / XCPC badge colors mirror Luogu's main site (verified against the upstream
+// getCCFLevel implementation, replicated in a long-running userscript):
+//   level < 3 → not shown
+//   level ≤ 5 → green
+//   level ≤ 7 → blue
+//   level ≥ 8 → gold
+function levelColor(level: number): string | null {
+    if (level < 3) return null;
+    if (level <= 5) return '#5eb95e';
+    if (level <= 7) return '#07a2f1';
+    return '#f1c40f';
+}
+
+const oi = computed(() => {
+    const color = levelColor(props.ccfLevel ?? 0);
+    if (!color) return null;
+    return { color, label: `OI 等级 ${props.ccfLevel}` };
+});
+
+const xcpc = computed(() => {
+    const color = levelColor(props.xcpcLevel ?? 0);
+    if (!color) return null;
+    return { color, label: `ICPC/CCPC 等级 ${props.xcpcLevel}` };
+});
+
+// OI: certified badge — 16x16 viewBox, fill-only path (Luogu's exact rendering).
+const OI_PATH =
+    'M16 8C16 6.84375 15.25 5.84375 14.1875 5.4375C14.6562 4.4375 14.4688 3.1875 13.6562 2.34375C12.8125 1.53125 11.5625 1.34375 10.5625 1.8125C10.1562 0.75 9.15625 0 8 0C6.8125 0 5.8125 0.75 5.40625 1.8125C4.40625 1.34375 3.15625 1.53125 2.34375 2.34375C1.5 3.1875 1.3125 4.4375 1.78125 5.4375C0.71875 5.84375 0 6.84375 0 8C0 9.1875 0.71875 10.1875 1.78125 10.5938C1.3125 11.5938 1.5 12.8438 2.34375 13.6562C3.15625 14.5 4.40625 14.6875 5.40625 14.2188C5.8125 15.2812 6.8125 16 8 16C9.15625 16 10.1562 15.2812 10.5625 14.2188C11.5938 14.6875 12.8125 14.5 13.6562 13.6562C14.4688 12.8438 14.6562 11.5938 14.1875 10.5938C15.25 10.1875 16 9.1875 16 8ZM11.4688 6.625L7.375 10.6875C7.21875 10.8438 7 10.8125 6.875 10.6875L4.5 8.3125C4.375 8.1875 4.375 7.96875 4.5 7.8125L5.3125 7C5.46875 6.875 5.6875 6.875 5.8125 7.03125L7.125 8.34375L10.1562 5.34375C10.3125 5.1875 10.5312 5.1875 10.6562 5.34375L11.4688 6.15625C11.5938 6.28125 11.5938 6.5 11.4688 6.625Z';
+
+// XCPC: balloon — 384x512 viewBox, Font Awesome 6 `fa-balloon` path,
+// matching the icon Luogu uses on user pages.
+const XCPC_PATH =
+    'M0 192C0 86 86 0 192 0S384 86 384 192c0 128-160 240-160 240l27.9 41.8c2.7 4 4.1 8.8 4.1 13.6 0 13.6-11 24.6-24.6 24.6l-78.9 0c-13.6 0-24.6-11-24.6-24.6 0-4.8 1.4-9.6 4.1-13.6L160 432S0 320 0 192zm104-16c0-39.8 32.2-72 72-72 13.3 0 24-10.7 24-24s-10.7-24-24-24c-66.3 0-120 53.7-120 120 0 13.3 10.7 24 24 24s24-10.7 24-24z';
+</script>
+
+<template>
+    <span v-if="oi || xcpc" class="user-prize-badges" :style="{ height: `${size}px` }">
+        <n-tooltip v-if="oi" :delay="200">
+            <template #trigger>
+                <svg
+                    class="user-prize-badge"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 16 16"
+                    :width="size"
+                    :height="size"
+                    :fill="oi.color"
+                    role="img"
+                    :aria-label="oi.label"
+                >
+                    <path :d="OI_PATH" />
+                </svg>
+            </template>
+            {{ oi.label }}
+        </n-tooltip>
+
+        <n-tooltip v-if="xcpc" :delay="200">
+            <template #trigger>
+                <svg
+                    class="user-prize-badge"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 384 512"
+                    :width="size"
+                    :height="size"
+                    :fill="xcpc.color"
+                    role="img"
+                    :aria-label="xcpc.label"
+                >
+                    <path :d="XCPC_PATH" />
+                </svg>
+            </template>
+            {{ xcpc.label }}
+        </n-tooltip>
+    </span>
+</template>
+
+<style scoped>
+.user-prize-badges {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    margin-left: 4px;
+    vertical-align: middle;
+    line-height: 1;
+}
+.user-prize-badge {
+    display: inline-block;
+    vertical-align: middle;
+}
+</style>

--- a/packages/frontend/src/routers/modules/user.ts
+++ b/packages/frontend/src/routers/modules/user.ts
@@ -1,0 +1,12 @@
+import type { RouteRecordRaw } from 'vue-router';
+
+export default [
+    {
+        path: '/user/:id',
+        name: 'user-profile',
+        component: () => import('@/views/user/UserProfileView.vue'),
+        meta: {
+            activeMenu: ''
+        }
+    }
+] as RouteRecordRaw[];

--- a/packages/frontend/src/types/user.d.ts
+++ b/packages/frontend/src/types/user.d.ts
@@ -10,8 +10,11 @@ export interface User {
 
 export interface UserPrize {
     year: number;
-    contestName: string;
+    contest: string;
+    event: string | null;
     prize: string;
+    score?: number;
+    rank?: number;
 }
 
 export interface UserProfile {
@@ -20,6 +23,8 @@ export interface UserProfile {
     color: string;
     ccfLevel: number;
     xcpcLevel: number;
+    slogan: string | null;
+    renderedIntroduction: string | null;
     prizes: UserPrize[] | null;
     profileFetchedAt: string | null;
     profileStale: boolean;

--- a/packages/frontend/src/types/user.d.ts
+++ b/packages/frontend/src/types/user.d.ts
@@ -2,6 +2,27 @@ export interface User {
     id: number;
     name?: string;
     color?: string;
+    ccfLevel?: number;
+    xcpcLevel?: number;
     createdAt: number;
     updatedAt: number;
+}
+
+export interface UserPrize {
+    year: number;
+    contestName: string;
+    prize: string;
+}
+
+export interface UserProfile {
+    id: number;
+    name: string;
+    color: string;
+    ccfLevel: number;
+    xcpcLevel: number;
+    prizes: UserPrize[] | null;
+    profileFetchedAt: string | null;
+    profileStale: boolean;
+    createdAt: string;
+    updatedAt: string;
 }

--- a/packages/frontend/src/views/user/UserProfileView.vue
+++ b/packages/frontend/src/views/user/UserProfileView.vue
@@ -1,0 +1,311 @@
+<script setup lang="ts">
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
+import { NAvatar, NSpin, NEmpty, NTag, NTime, NSpace, NButton, NIcon, useMessage } from 'naive-ui';
+import { SyncOutline, TrophyOutline, RibbonOutline } from '@vicons/ionicons5';
+
+import { getUserProfile, refreshUserProfile } from '@/api/user';
+import socket from '@/utils/websocket';
+import type { UserProfile, UserPrize } from '@/types/user';
+
+import Card from '@/components/Card.vue';
+import UserPrizeBadge from '@/components/UserPrizeBadge.vue';
+
+const route = useRoute();
+const message = useMessage();
+
+const loading = ref(true);
+const notFound = ref(false);
+const profile = ref<UserProfile | null>(null);
+const refreshing = ref(false);
+
+const uid = computed(() => {
+    const raw = route.params.id;
+    if (typeof raw !== 'string') return null;
+    if (!/^[1-9]\d*$/.test(raw)) return null;
+    return Number(raw);
+});
+
+const colorClass = computed(() => `user-${profile.value?.color || 'Gray'}`);
+
+const groupedPrizes = computed(() => {
+    if (!profile.value?.prizes || profile.value.prizes.length === 0) return [];
+    const groups = new Map<number, UserPrize[]>();
+    for (const p of profile.value.prizes) {
+        const list = groups.get(p.year) ?? [];
+        list.push(p);
+        groups.set(p.year, list);
+    }
+    return [...groups.entries()]
+        .sort((a, b) => b[0] - a[0])
+        .map(([year, prizes]) => ({ year, prizes }));
+});
+
+const room = computed(() => (uid.value !== null ? `user_${uid.value}` : null));
+const event = computed(() => (uid.value !== null ? `user:${uid.value}:profile-updated` : null));
+
+let listenerAttached = false;
+
+function onProfileUpdated() {
+    if (uid.value === null) return;
+    // soft reload without changing layout
+    void reload(/* silent */ true);
+}
+
+function attachSocket() {
+    if (listenerAttached || !room.value || !event.value) return;
+    socket.joinRoom(room.value);
+    socket.getInstance().on(event.value, onProfileUpdated);
+    listenerAttached = true;
+}
+
+function detachSocket() {
+    if (!listenerAttached || !room.value || !event.value) return;
+    socket.getInstance().off(event.value, onProfileUpdated);
+    socket.leaveRoom(room.value);
+    listenerAttached = false;
+}
+
+async function reload(silent = false) {
+    if (uid.value === null) return;
+    if (!silent) loading.value = true;
+    notFound.value = false;
+    try {
+        const res = await getUserProfile(uid.value);
+        if (res.code !== 200 || !res.data) {
+            notFound.value = true;
+            profile.value = null;
+        } else {
+            profile.value = res.data;
+        }
+    } catch (e: any) {
+        const status = e?.response?.status;
+        if (status === 404) {
+            notFound.value = true;
+            profile.value = null;
+        } else {
+            message.error(e?.message || '加载用户信息失败');
+        }
+    } finally {
+        if (!silent) loading.value = false;
+    }
+}
+
+async function handleManualRefresh() {
+    if (uid.value === null || refreshing.value) return;
+    refreshing.value = true;
+    try {
+        await refreshUserProfile(uid.value);
+        message.info('已请求刷新,稍后将自动更新');
+    } catch (e: any) {
+        message.error(e?.message || '刷新失败');
+    } finally {
+        refreshing.value = false;
+    }
+}
+
+watch(uid, async () => {
+    detachSocket();
+    profile.value = null;
+    if (uid.value === null) {
+        notFound.value = true;
+        loading.value = false;
+        return;
+    }
+    await reload();
+    attachSocket();
+});
+
+onMounted(async () => {
+    if (uid.value === null) {
+        notFound.value = true;
+        loading.value = false;
+        return;
+    }
+    await reload();
+    attachSocket();
+});
+
+onUnmounted(() => {
+    detachSocket();
+});
+</script>
+
+<template>
+    <div class="user-profile-view">
+        <n-spin :show="loading">
+            <Card v-if="!loading && notFound">
+                <n-empty description="未找到该用户" />
+            </Card>
+
+            <template v-else-if="profile">
+                <Card>
+                    <div class="profile-header">
+                        <n-avatar
+                            round
+                            :size="72"
+                            :src="`https://cdn.luogu.com.cn/upload/usericon/${profile.id}.png`"
+                        />
+                        <div class="profile-header-main">
+                            <div class="profile-name-row">
+                                <span class="profile-name user-name" :class="colorClass">
+                                    {{ profile.name }}
+                                </span>
+                                <UserPrizeBadge
+                                    v-if="profile.ccfLevel > 0 || profile.xcpcLevel > 0"
+                                    :ccf-level="profile.ccfLevel"
+                                    :xcpc-level="profile.xcpcLevel"
+                                    :size="18"
+                                />
+                            </div>
+                            <div class="profile-meta">
+                                <span>UID {{ profile.id }}</span>
+                                <span v-if="profile.ccfLevel > 0">
+                                    OI 等级 {{ profile.ccfLevel }}
+                                </span>
+                                <span v-if="profile.xcpcLevel > 0">
+                                    XCPC 等级 {{ profile.xcpcLevel }}
+                                </span>
+                            </div>
+                            <div class="profile-meta-faint">
+                                <template v-if="profile.profileFetchedAt">
+                                    数据更新于
+                                    <n-time
+                                        :time="new Date(profile.profileFetchedAt)"
+                                        type="relative"
+                                    />
+                                </template>
+                                <template v-else> 尚未拉取完整资料 </template>
+                                <template v-if="profile.profileStale"> · 后台正在刷新中 </template>
+                            </div>
+                        </div>
+                        <n-button secondary :loading="refreshing" @click="handleManualRefresh">
+                            <template #icon>
+                                <n-icon><SyncOutline /></n-icon>
+                            </template>
+                            刷新
+                        </n-button>
+                    </div>
+                </Card>
+
+                <Card style="margin-top: 16px">
+                    <template #title>
+                        <n-space align="center" :size="8">
+                            <n-icon size="20"><TrophyOutline /></n-icon>
+                            <span>获奖历史</span>
+                        </n-space>
+                    </template>
+
+                    <n-empty
+                        v-if="!profile.prizes || profile.prizes.length === 0"
+                        :description="
+                            profile.profileFetchedAt
+                                ? '该用户暂无可见的获奖记录'
+                                : '正在拉取数据,请稍候...'
+                        "
+                    />
+
+                    <div v-else class="prize-groups">
+                        <div v-for="group in groupedPrizes" :key="group.year" class="prize-group">
+                            <div class="prize-year">{{ group.year }}</div>
+                            <div class="prize-list">
+                                <div
+                                    v-for="(prize, idx) in group.prizes"
+                                    :key="idx"
+                                    class="prize-item"
+                                >
+                                    <n-icon size="16" class="prize-item-icon">
+                                        <RibbonOutline />
+                                    </n-icon>
+                                    <span class="prize-item-contest">
+                                        {{ prize.contestName }}
+                                    </span>
+                                    <n-tag size="small" type="success" :bordered="false">
+                                        {{ prize.prize }}
+                                    </n-tag>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </Card>
+            </template>
+        </n-spin>
+    </div>
+</template>
+
+<style scoped>
+.user-profile-view {
+    max-width: 960px;
+    margin: 0 auto;
+}
+.profile-header {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+}
+.profile-header-main {
+    flex: 1;
+    min-width: 0;
+}
+.profile-name-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+.profile-name {
+    font-size: 24px;
+    font-weight: 700;
+}
+.profile-meta {
+    display: flex;
+    gap: 14px;
+    margin-top: 6px;
+    color: var(--n-text-color-2, #666);
+    font-size: 14px;
+    flex-wrap: wrap;
+}
+.profile-meta-faint {
+    margin-top: 4px;
+    color: var(--n-text-color-3, #999);
+    font-size: 12px;
+}
+.prize-groups {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+.prize-group {
+    display: flex;
+    gap: 18px;
+    align-items: flex-start;
+}
+.prize-year {
+    flex: 0 0 64px;
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--n-text-color-1, #333);
+    padding-top: 2px;
+}
+.prize-list {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.prize-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.prize-item-icon {
+    color: #d4af37;
+    flex-shrink: 0;
+}
+.prize-item-contest {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+</style>

--- a/packages/frontend/src/views/user/UserProfileView.vue
+++ b/packages/frontend/src/views/user/UserProfileView.vue
@@ -1,14 +1,26 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
-import { NAvatar, NSpin, NEmpty, NTag, NTime, NSpace, NButton, NIcon, useMessage } from 'naive-ui';
-import { SyncOutline, TrophyOutline, RibbonOutline } from '@vicons/ionicons5';
+import {
+    NAvatar,
+    NSpin,
+    NEmpty,
+    NTag,
+    NTime,
+    NSpace,
+    NButton,
+    NIcon,
+    NTooltip,
+    useMessage
+} from 'naive-ui';
+import { SyncOutline, TrophyOutline, ReaderOutline, PersonCircleOutline } from '@vicons/ionicons5';
 
 import { getUserProfile, refreshUserProfile } from '@/api/user';
 import socket from '@/utils/websocket';
-import type { UserProfile, UserPrize } from '@/types/user';
+import type { UserProfile } from '@/types/user';
 
 import Card from '@/components/Card.vue';
+import MarkdownViewer from '@/components/MarkdownViewer.vue';
 import UserPrizeBadge from '@/components/UserPrizeBadge.vue';
 
 const route = useRoute();
@@ -28,17 +40,23 @@ const uid = computed(() => {
 
 const colorClass = computed(() => `user-${profile.value?.color || 'Gray'}`);
 
-const groupedPrizes = computed(() => {
-    if (!profile.value?.prizes || profile.value.prizes.length === 0) return [];
-    const groups = new Map<number, UserPrize[]>();
-    for (const p of profile.value.prizes) {
-        const list = groups.get(p.year) ?? [];
-        list.push(p);
-        groups.set(p.year, list);
-    }
-    return [...groups.entries()]
-        .sort((a, b) => b[0] - a[0])
-        .map(([year, prizes]) => ({ year, prizes }));
+// Award level → tag type mapping. The strings are free-form from Luogu, so we use
+// substring matching on the user-visible terms.
+function prizeTagType(prize: string): 'success' | 'warning' | 'error' | 'info' | 'default' {
+    if (prize.includes('金')) return 'warning';
+    if (prize.includes('银')) return 'default';
+    if (prize.includes('铜')) return 'error';
+    if (prize.includes('一等')) return 'warning';
+    if (prize.includes('二等')) return 'default';
+    if (prize.includes('三等')) return 'error';
+    return 'info';
+}
+
+// Prizes are pre-sorted by Luogu in chronological order. Reverse for display so the
+// most recent contest appears at the top.
+const orderedPrizes = computed(() => {
+    if (!profile.value?.prizes) return [];
+    return [...profile.value.prizes].reverse();
 });
 
 const room = computed(() => (uid.value !== null ? `user_${uid.value}` : null));
@@ -48,7 +66,6 @@ let listenerAttached = false;
 
 function onProfileUpdated() {
     if (uid.value === null) return;
-    // soft reload without changing layout
     void reload(/* silent */ true);
 }
 
@@ -138,174 +155,373 @@ onUnmounted(() => {
                 <n-empty description="未找到该用户" />
             </Card>
 
-            <template v-else-if="profile">
-                <Card>
-                    <div class="profile-header">
-                        <n-avatar
-                            round
-                            :size="72"
-                            :src="`https://cdn.luogu.com.cn/upload/usericon/${profile.id}.png`"
+            <div v-else-if="profile" class="profile-grid">
+                <!-- LEFT COLUMN: introduction (Markdown) -->
+                <div class="profile-left">
+                    <Card class="profile-card profile-card--intro">
+                        <template #title>
+                            <n-space align="center" :size="8">
+                                <n-icon size="20"><ReaderOutline /></n-icon>
+                                <span>个人介绍</span>
+                            </n-space>
+                        </template>
+
+                        <MarkdownViewer
+                            v-if="profile.renderedIntroduction"
+                            :content="profile.renderedIntroduction"
                         />
-                        <div class="profile-header-main">
-                            <div class="profile-name-row">
-                                <span class="profile-name user-name" :class="colorClass">
-                                    {{ profile.name }}
-                                </span>
-                                <UserPrizeBadge
-                                    v-if="profile.ccfLevel > 0 || profile.xcpcLevel > 0"
-                                    :ccf-level="profile.ccfLevel"
-                                    :xcpc-level="profile.xcpcLevel"
-                                    :size="18"
-                                />
-                            </div>
-                            <div class="profile-meta">
-                                <span>UID {{ profile.id }}</span>
-                                <span v-if="profile.ccfLevel > 0">
-                                    OI 等级 {{ profile.ccfLevel }}
-                                </span>
-                                <span v-if="profile.xcpcLevel > 0">
-                                    XCPC 等级 {{ profile.xcpcLevel }}
-                                </span>
-                            </div>
-                            <div class="profile-meta-faint">
-                                <template v-if="profile.profileFetchedAt">
-                                    数据更新于
-                                    <n-time
-                                        :time="new Date(profile.profileFetchedAt)"
-                                        type="relative"
-                                    />
-                                </template>
-                                <template v-else> 尚未拉取完整资料 </template>
-                                <template v-if="profile.profileStale"> · 后台正在刷新中 </template>
-                            </div>
-                        </div>
-                        <n-button secondary :loading="refreshing" @click="handleManualRefresh">
-                            <template #icon>
-                                <n-icon><SyncOutline /></n-icon>
-                            </template>
-                            刷新
-                        </n-button>
-                    </div>
-                </Card>
+                        <n-empty v-else description="该用户暂无个人介绍" />
+                    </Card>
+                </div>
 
-                <Card style="margin-top: 16px">
-                    <template #title>
-                        <n-space align="center" :size="8">
-                            <n-icon size="20"><TrophyOutline /></n-icon>
-                            <span>获奖历史</span>
-                        </n-space>
-                    </template>
+                <!-- RIGHT COLUMN: identity card + compact prizes list -->
+                <div class="profile-right">
+                    <Card class="profile-card profile-card--identity">
+                        <template #title>
+                            <n-space align="center" :size="8">
+                                <n-icon size="20"><PersonCircleOutline /></n-icon>
+                                <span>个人信息</span>
+                            </n-space>
+                        </template>
 
-                    <n-empty
-                        v-if="!profile.prizes || profile.prizes.length === 0"
-                        :description="
-                            profile.profileFetchedAt
-                                ? '该用户暂无可见的获奖记录'
-                                : '正在拉取数据,请稍候...'
-                        "
-                    />
-
-                    <div v-else class="prize-groups">
-                        <div v-for="group in groupedPrizes" :key="group.year" class="prize-group">
-                            <div class="prize-year">{{ group.year }}</div>
-                            <div class="prize-list">
-                                <div
-                                    v-for="(prize, idx) in group.prizes"
-                                    :key="idx"
-                                    class="prize-item"
-                                >
-                                    <n-icon size="16" class="prize-item-icon">
-                                        <RibbonOutline />
-                                    </n-icon>
-                                    <span class="prize-item-contest">
-                                        {{ prize.contestName }}
+                        <div class="identity-header">
+                            <n-avatar
+                                round
+                                :size="56"
+                                :src="`https://cdn.luogu.com.cn/upload/usericon/${profile.id}.png`"
+                            />
+                            <div class="identity-name-block">
+                                <div class="identity-name-row">
+                                    <span class="identity-name user-name" :class="colorClass">
+                                        {{ profile.name }}
                                     </span>
-                                    <n-tag size="small" type="success" :bordered="false">
-                                        {{ prize.prize }}
-                                    </n-tag>
+                                    <UserPrizeBadge
+                                        v-if="profile.ccfLevel > 0 || profile.xcpcLevel > 0"
+                                        :ccf-level="profile.ccfLevel"
+                                        :xcpc-level="profile.xcpcLevel"
+                                        :size="16"
+                                    />
+                                </div>
+                                <div v-if="profile.slogan" class="identity-slogan">
+                                    {{ profile.slogan }}
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </Card>
-            </template>
+
+                        <dl class="identity-fields">
+                            <div class="identity-field">
+                                <dt>UID</dt>
+                                <dd>{{ profile.id }}</dd>
+                            </div>
+                            <div v-if="profile.ccfLevel > 0" class="identity-field">
+                                <dt>OI 等级</dt>
+                                <dd>{{ profile.ccfLevel }} 级</dd>
+                            </div>
+                            <div v-if="profile.xcpcLevel > 0" class="identity-field">
+                                <dt>ICPC/CCPC 等级</dt>
+                                <dd>{{ profile.xcpcLevel }} 级</dd>
+                            </div>
+                            <div class="identity-field identity-field--faint">
+                                <dt>更新于</dt>
+                                <dd>
+                                    <template v-if="profile.profileFetchedAt">
+                                        <n-time
+                                            :time="new Date(profile.profileFetchedAt)"
+                                            type="relative"
+                                        />
+                                    </template>
+                                    <template v-else>尚未拉取完整资料</template>
+                                </dd>
+                            </div>
+                        </dl>
+
+                        <div class="identity-actions">
+                            <n-button
+                                size="small"
+                                secondary
+                                :loading="refreshing"
+                                @click="handleManualRefresh"
+                            >
+                                <template #icon>
+                                    <n-icon><SyncOutline /></n-icon>
+                                </template>
+                                刷新
+                            </n-button>
+                            <span v-if="profile.profileStale" class="identity-stale">
+                                后台刷新中
+                            </span>
+                        </div>
+                    </Card>
+
+                    <Card class="profile-card profile-card--prizes">
+                        <template #title>
+                            <n-space align="center" :size="8">
+                                <n-icon size="20"><TrophyOutline /></n-icon>
+                                <span>获奖信息</span>
+                            </n-space>
+                        </template>
+
+                        <n-empty
+                            v-if="orderedPrizes.length === 0"
+                            :description="
+                                profile.profileFetchedAt
+                                    ? '该用户暂无可见的获奖记录'
+                                    : '正在拉取数据,请稍候...'
+                            "
+                        />
+
+                        <ul v-else class="prize-list-compact">
+                            <li v-for="(prize, idx) in orderedPrizes" :key="idx" class="prize-row">
+                                <n-tooltip
+                                    v-if="prize.score != null || prize.rank != null"
+                                    :delay="200"
+                                >
+                                    <template #trigger>
+                                        <div class="prize-row-text">
+                                            <span class="prize-row-year">[{{ prize.year }}]</span>
+                                            <span class="prize-row-contest">
+                                                {{ prize.contest }}
+                                            </span>
+                                            <span v-if="prize.event" class="prize-row-event">
+                                                · {{ prize.event }}
+                                            </span>
+                                        </div>
+                                    </template>
+                                    <div class="prize-tooltip">
+                                        <div v-if="prize.score != null">
+                                            成绩: {{ prize.score }}
+                                        </div>
+                                        <div v-if="prize.rank != null">排名: {{ prize.rank }}</div>
+                                    </div>
+                                </n-tooltip>
+                                <div v-else class="prize-row-text">
+                                    <span class="prize-row-year">[{{ prize.year }}]</span>
+                                    <span class="prize-row-contest">{{ prize.contest }}</span>
+                                    <span v-if="prize.event" class="prize-row-event">
+                                        · {{ prize.event }}
+                                    </span>
+                                </div>
+                                <n-tag
+                                    size="small"
+                                    :type="prizeTagType(prize.prize)"
+                                    :bordered="false"
+                                >
+                                    {{ prize.prize }}
+                                </n-tag>
+                            </li>
+                        </ul>
+                    </Card>
+                </div>
+            </div>
         </n-spin>
     </div>
 </template>
 
 <style scoped>
 .user-profile-view {
-    max-width: 960px;
+    max-width: 1200px;
     margin: 0 auto;
-}
-.profile-header {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-}
-.profile-header-main {
-    flex: 1;
     min-width: 0;
 }
-.profile-name-row {
+
+.profile-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+    gap: 16px;
+    align-items: start;
+    min-width: 0;
+}
+
+@media (max-width: 900px) {
+    .profile-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.profile-left,
+.profile-right {
+    min-width: 0;
     display: flex;
-    align-items: center;
-    gap: 4px;
+    flex-direction: column;
+    gap: 16px;
+    /* prevent any oversized child from overflowing the grid cell */
+    overflow: hidden;
 }
-.profile-name {
-    font-size: 24px;
-    font-weight: 700;
+
+.profile-card {
+    width: 100%;
+    box-sizing: border-box;
+    /* belt-and-suspenders: even if a child has fixed width, clip it */
+    overflow: hidden;
 }
-.profile-meta {
+.profile-card :deep(*) {
+    box-sizing: border-box;
+}
+
+/* Constrain Markdown content that would otherwise blow up the grid */
+.profile-card--intro :deep(img),
+.profile-card--intro :deep(video) {
+    max-width: 100%;
+    height: auto;
+}
+.profile-card--intro :deep(pre) {
+    max-width: 100%;
+    overflow-x: auto;
+}
+.profile-card--intro :deep(.table-container),
+.profile-card--intro :deep(table) {
+    max-width: 100%;
+    overflow-x: auto;
+    display: block;
+}
+.profile-card--intro :deep(iframe) {
+    max-width: 100%;
+}
+
+/* Identity card */
+.identity-header {
     display: flex;
     gap: 14px;
-    margin-top: 6px;
-    color: var(--n-text-color-2, #666);
-    font-size: 14px;
-    flex-wrap: wrap;
-}
-.profile-meta-faint {
-    margin-top: 4px;
-    color: var(--n-text-color-3, #999);
-    font-size: 12px;
-}
-.prize-groups {
-    display: flex;
-    flex-direction: column;
-    gap: 18px;
-}
-.prize-group {
-    display: flex;
-    gap: 18px;
-    align-items: flex-start;
-}
-.prize-year {
-    flex: 0 0 64px;
-    font-size: 18px;
-    font-weight: 700;
-    color: var(--n-text-color-1, #333);
-    padding-top: 2px;
-}
-.prize-list {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-}
-.prize-item {
-    display: flex;
     align-items: center;
-    gap: 8px;
+    margin-bottom: 14px;
+    min-width: 0;
 }
-.prize-item-icon {
-    color: #d4af37;
-    flex-shrink: 0;
-}
-.prize-item-contest {
+.identity-name-block {
     flex: 1;
     min-width: 0;
     overflow: hidden;
+}
+.identity-name-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+}
+.identity-name {
+    font-size: 18px;
+    font-weight: 700;
+    overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    min-width: 0;
+}
+.identity-slogan {
+    margin-top: 4px;
+    color: var(--n-text-color-2, #666);
+    font-size: 13px;
+    line-height: 1.4;
+    font-style: italic;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    /* break long English/URLs so flex children don't blow out the column */
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.identity-fields {
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+.identity-field {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    padding: 6px 0;
+    border-bottom: 1px solid var(--n-divider-color, #eee);
+    min-width: 0;
+}
+.identity-field:last-child {
+    border-bottom: none;
+}
+.identity-field dt {
+    margin: 0;
+    flex-shrink: 0;
+    color: var(--n-text-color-2, #666);
+    font-size: 13px;
+    white-space: nowrap;
+}
+.identity-field dd {
+    margin: 0;
+    flex: 1;
+    min-width: 0;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--n-text-color-1, #333);
+    text-align: right;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.identity-field--faint dd {
+    font-weight: 400;
+    color: var(--n-text-color-3, #999);
+    font-size: 12px;
+}
+
+.identity-actions {
+    margin-top: 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.identity-stale {
+    font-size: 12px;
+    color: var(--n-text-color-3, #999);
+}
+
+/* Compact prize list */
+.prize-list-compact {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+}
+.prize-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--n-divider-color, #eee);
+}
+.prize-row:last-child {
+    border-bottom: none;
+}
+.prize-row-text {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    font-size: 14px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.prize-row-year {
+    color: var(--n-text-color-3, #999);
+    font-variant-numeric: tabular-nums;
+    flex-shrink: 0;
+}
+.prize-row-contest {
+    color: var(--n-text-color-1, #333);
+    font-weight: 500;
+}
+.prize-row-event {
+    color: var(--n-text-color-3, #999);
+    font-size: 12px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.prize-tooltip {
+    font-size: 12px;
+    line-height: 1.6;
 }
 </style>

--- a/spec/luogu-integration.spec.md
+++ b/spec/luogu-integration.spec.md
@@ -182,23 +182,35 @@ interface UserSummary {
 ```typescript
 {
     data: {
+        prizes: {
+            prize: {
+                year: number;
+                contest: string;
+                event: string | null;
+                prize: string;
+                score?: number;
+                rank?: number;
+            };
+        }[];
         user: {
             uid: number;
             name: string;
             color: UserColor;
             ccfLevel: number;
             xcpcLevel: number;
-            prize: {
-                year: number;
-                contestName: string;
-                prize: string;
-            }
-            [];
+            slogan: string | null;        // short tagline, plain text
+            introduction: string | null;  // long bio in raw Markdown
             // ... other UserDetails fields
-        }
-    }
+        };
+    };
 }
 ```
+
+Notes:
+
+- The award list lives at `data.prizes` (top-level), not at `data.user.prize`. Each entry is a one-level wrapper `{ prize: LuoguPrize }`; consumers MUST unwrap the inner object before storing.
+- `data.user.prize` exists in Luogu's response but is unrelated to the certified award list and is typically empty for verified users. Do NOT read from it.
+- `data.user.introduction` is raw Markdown; the saver renders it via the shared `renderMarkdown` pipeline before storing.
 
 The saver consumes only the fields above; all other fields are ignored.
 
@@ -294,7 +306,7 @@ Convert Luogu user summary to local User entity:
 
 1. Parse `targetId` to a positive integer; reject otherwise.
 2. Fetch `https://www.luogu.com/user/{uid}` with `C3vkMode.MODERN`.
-3. Extract `user` and `prize` array from the response.
+3. Extract `user` from `response.data.user` and the award list from `response.data.prizes`, unwrapping the inner `prize` object of each entry.
 4. Call `UserService.saveLuoguUserProfile` with the extracted data.
 5. Emit Socket.IO event `user:{uid}:profile-updated`.
 

--- a/spec/luogu-integration.spec.md
+++ b/spec/luogu-integration.spec.md
@@ -167,8 +167,40 @@ interface UserSummary {
     uid: number;
     name: string;
     color: string;
+    ccfLevel: number; // OI / CCF certification level, 0 = none
+    xcpcLevel: number; // ICPC / CCPC certification level, 0 = none
+    // ... other fields present in upstream but unused by the saver
 }
 ```
+
+### 5.4 User Profile Fetch
+
+**URL Pattern:** `https://www.luogu.com/user/{uid}`
+
+**Response Structure:** `LentilleDataResponse<UserData>` where the relevant subset is:
+
+```typescript
+{
+    data: {
+        user: {
+            uid: number;
+            name: string;
+            color: UserColor;
+            ccfLevel: number;
+            xcpcLevel: number;
+            prize: {
+                year: number;
+                contestName: string;
+                prize: string;
+            }
+            [];
+            // ... other UserDetails fields
+        }
+    }
+}
+```
+
+The saver consumes only the fields above; all other fields are ignored.
 
 ## 6. User Building
 
@@ -180,9 +212,13 @@ Convert Luogu user summary to local User entity:
 {
     id: user.uid,
     name: user.name,
-    color: user.color as UserColor
+    color: user.color as UserColor,
+    ccfLevel: user.ccfLevel ?? 0,
+    xcpcLevel: user.xcpcLevel ?? 0
 }
 ```
+
+`buildUser` MUST NOT include `prizes` or `profileFetchedAt`. Those fields are only written by `ProfileHandler` via `UserService.saveLuoguUserProfile`. See `user-system.spec.md` for the full contract.
 
 ## 7. Task Handlers
 
@@ -240,6 +276,28 @@ Convert Luogu user summary to local User entity:
 5. Save paste to database.
 6. Update task status to COMPLETED.
 
+### 7.3 ProfileHandler
+
+**Task Type:** `save:profile`
+
+**Payload:**
+
+```typescript
+{
+    target: "profile",
+    targetId: string,  // Luogu UID as decimal string
+    metadata: {}
+}
+```
+
+**Processing:** Defined in `user-system.spec.md` Section 5.3. Briefly:
+
+1. Parse `targetId` to a positive integer; reject otherwise.
+2. Fetch `https://www.luogu.com/user/{uid}` with `C3vkMode.MODERN`.
+3. Extract `user` and `prize` array from the response.
+4. Call `UserService.saveLuoguUserProfile` with the extracted data.
+5. Emit Socket.IO event `user:{uid}:profile-updated`.
+
 ## 8. Invariants
 
 1. All Luogu API requests include the standard headers.
@@ -247,11 +305,14 @@ Convert Luogu user summary to local User entity:
 3. Network timeouts result in retriable errors.
 4. HTTP 401 and parse errors are unrecoverable.
 5. User entities are created/updated before content entities.
+6. `buildUser` propagates `ccfLevel` and `xcpcLevel` from upstream; missing values map to `0`.
+7. The inline `buildUser` path never overwrites `prizes` or `profile_fetched_at`.
 
 ## 9. File Locations
 
 - Fetch utility: `packages/backend/src/utils/fetch.ts`
 - Luogu API helpers: `packages/backend/src/utils/luogu-api.ts`
 - C3VK mode enum: `packages/backend/src/shared/c3vk.ts`
-- Article handler: `packages/backend/src/workers/handlers/task/article.handler.ts`
-- Paste handler: `packages/backend/src/workers/handlers/task/paste.handler.ts`
+- Article handler: `packages/backend/src/workers/handlers/task/save/article.handler.ts`
+- Paste handler: `packages/backend/src/workers/handlers/task/save/paste.handler.ts`
+- Profile handler: `packages/backend/src/workers/handlers/task/save/profile.handler.ts`

--- a/spec/task-queue.spec.md
+++ b/spec/task-queue.spec.md
@@ -217,10 +217,11 @@ interface TaskHandler<T extends CommonTask> {
 
 ### 7.3 Registered Handlers
 
-| Handler Key    | Handler Class  | Description                  |
-| -------------- | -------------- | ---------------------------- |
-| `save:article` | ArticleHandler | Fetch and save Luogu article |
-| `save:paste`   | PasteHandler   | Fetch and save Luogu paste   |
+| Handler Key    | Handler Class  | Description                       |
+| -------------- | -------------- | --------------------------------- |
+| `save:article` | ArticleHandler | Fetch and save Luogu article      |
+| `save:paste`   | PasteHandler   | Fetch and save Luogu paste        |
+| `save:profile` | ProfileHandler | Fetch and save Luogu user profile |
 
 ## 8. Configuration
 

--- a/spec/user-system.spec.md
+++ b/spec/user-system.spec.md
@@ -1,0 +1,256 @@
+# User System Specification
+
+## 1. Overview
+
+The user system stores Luogu user records mirrored from the upstream platform. Beyond identity (`id`, `name`) and the dynamic color level (`color`), it records the user's award certification levels (OI / XCPC), the full award history when available, and metadata used to manage the freshness of the cached profile.
+
+The system exposes:
+
+1. Inline read paths used by content handlers (article, paste): `id`, `name`, `color`, `ccfLevel`, `xcpcLevel`.
+2. A profile read path used by the user homepage: all of the above plus `prizes` and `profileFetchedAt`.
+3. A `save:profile` task that fetches the full Luogu user page and refreshes the profile-only fields.
+
+## 2. User Entity
+
+### 2.1 Schema
+
+Table name: `user`
+
+| Column               | Type         | Constraints           | Description                                         |
+| -------------------- | ------------ | --------------------- | --------------------------------------------------- |
+| `id`                 | INT UNSIGNED | PRIMARY KEY           | Luogu user ID                                       |
+| `name`               | VARCHAR      | NOT NULL              | Luogu user name                                     |
+| `color`              | VARCHAR      | NOT NULL              | Dynamic level color (UserColor enum)                |
+| `ccf_level`          | INT          | NOT NULL, DEFAULT `0` | OI / CCF certification level (`0` = none)           |
+| `xcpc_level`         | INT          | NOT NULL, DEFAULT `0` | ICPC / CCPC certification level (`0` = none)        |
+| `prizes`             | JSON         | NULLABLE              | Array of `UserPrize` records; `NULL` if not fetched |
+| `profile_fetched_at` | DATETIME     | NULLABLE              | Timestamp of the last successful profile fetch      |
+| `created_at`         | DATETIME     | NOT NULL              | Record creation timestamp                           |
+| `updated_at`         | DATETIME     | NOT NULL              | Record update timestamp                             |
+
+### 2.2 UserColor Enum
+
+Unchanged from `packages/backend/src/shared/user.ts`. Values: `Gray`, `Blue`, `Green`, `Orange`, `Red`, `Purple`, `Cheater`.
+
+### 2.3 UserPrize Type
+
+```typescript
+interface UserPrize {
+    year: number; // Award year, e.g. 2023
+    contestName: string; // Award contest name, free-form string from Luogu
+    prize: string; // Award level/name, free-form string from Luogu
+}
+```
+
+`UserPrize` is stored as one element of the `prizes` JSON array. The shape mirrors the `prize` field in Luogu's `UserDetails` response (`packages/backend/src/types/luogu-api.d.ts`, interface `UserDetails`).
+
+### 2.4 Level Semantics
+
+- `ccfLevel === 0` means the user has no OI certification, OR the user has chosen not to display it on Luogu. The system treats these cases identically.
+- `xcpcLevel === 0` means the user has no XCPC certification, OR has chosen not to display it. Identical treatment.
+- A non-zero level always implies the certification is publicly visible.
+
+The display layer is responsible for mapping `ccfLevel` / `xcpcLevel` to badge colors; this entity holds only the integer value.
+
+### 2.5 Profile Freshness
+
+A user profile (`prizes`, `profile_fetched_at`) is **stale** if any of the following hold:
+
+1. `profile_fetched_at IS NULL`.
+2. `now() - profile_fetched_at > PROFILE_TTL_MS` where `PROFILE_TTL_MS = 24 * 60 * 60 * 1000` (24 hours).
+
+A stale profile MAY still be returned to clients; staleness only triggers a background refresh task as described in Section 5.
+
+## 3. Upsert Semantics (from Luogu UserSummary)
+
+Inline content handlers (article, paste) call `UserService.upsertLuoguUser(data)` with the result of `buildUser(luoguUser)`.
+
+`buildUser(user: UserSummary): Partial<User>` MUST produce:
+
+```typescript
+{
+    id: user.uid,
+    name: user.name,
+    color: user.color as UserColor,
+    ccfLevel: user.ccfLevel ?? 0,
+    xcpcLevel: user.xcpcLevel ?? 0
+}
+```
+
+`buildUser` MUST NOT touch `prizes` or `profileFetchedAt`. These fields are only written by the profile task handler (Section 5).
+
+`UserService.upsertLuoguUser`:
+
+1. Requires `data.id` to be defined; throws otherwise.
+2. Performs a TypeORM upsert on the primary key.
+3. Evicts the cache key `user:{id}`.
+4. Does NOT mutate `prizes` or `profile_fetched_at` even if `data` happens to contain them.
+
+This invariant guarantees that the cheap inline path never clobbers richer data fetched by the profile task.
+
+## 4. UserService API
+
+All methods accept an optional `EntityManager` argument. If absent, the default repository manager is used.
+
+### 4.1 `getUserById(id: number, manager?): Promise<User | null>`
+
+1. Cached under `user:{id}` for 600 seconds.
+2. Returns the full `User` row including `prizes` and `profileFetchedAt`.
+
+### 4.2 `getUserByIdWithoutCache(id: number): Promise<User | null>`
+
+Same query as `getUserById` but bypasses the cache.
+
+### 4.3 `upsertLuoguUser(data: Partial<User>, manager?): Promise<User>`
+
+Behavior defined in Section 3.
+
+### 4.4 `saveLuoguUserProfile(data: { uid; name; color; ccfLevel; xcpcLevel; prizes }, manager?): Promise<User>`
+
+Profile-task write path. MUST:
+
+1. Upsert the user row using the primary key.
+2. Set `ccf_level`, `xcpc_level`, `prizes`, AND `profile_fetched_at = now()` atomically.
+3. Update `name` and `color` to the incoming values (the profile fetch is authoritative for the moment).
+4. Evict cache key `user:{id}`.
+
+### 4.5 `isProfileStale(user: User | null): boolean`
+
+Returns `true` iff:
+
+1. `user === null`, OR
+2. `user.prizes === null`, OR
+3. `user.profileFetchedAt === null`, OR
+4. `Date.now() - user.profileFetchedAt.getTime() > PROFILE_TTL_MS`.
+
+## 5. Save Profile Task
+
+### 5.1 Task Type
+
+| Handler Key    | Handler Class  | Description                                 |
+| -------------- | -------------- | ------------------------------------------- |
+| `save:profile` | ProfileHandler | Fetch and save full Luogu user profile data |
+
+The handler is registered in `packages/backend/src/workers/index.ts` alongside `ArticleHandler` and `PasteHandler`.
+
+### 5.2 Payload
+
+```typescript
+{
+    target: 'profile',
+    targetId: string,  // String form of Luogu UID; parsed to number internally
+    metadata: {
+        forceUpdate?: boolean  // Reserved; currently unused, profile fetch always overwrites
+    }
+}
+```
+
+`targetId` MUST be a non-empty string of decimal digits. The handler MUST reject any other input by throwing an `UnrecoverableError`.
+
+### 5.3 Processing Flow
+
+1. Parse `targetId` to `uid: number`. Reject NaN, negative, or zero with `UnrecoverableError`.
+2. Fetch `https://www.luogu.com/user/{uid}` via the shared `fetch` utility with `C3vkMode.MODERN`.
+3. Validate that the response has shape `LentilleDataResponse<UserData>`; reject with `UnrecoverableError` otherwise.
+4. Extract:
+    - `user: UserDetails` from `response.data.user`
+    - `prizes: UserPrize[]` from `response.data.user.prize` (defensive: default to `[]` if absent or non-array)
+5. Build the payload for `UserService.saveLuoguUserProfile`:
+    ```typescript
+    {
+        uid: user.uid,
+        name: user.name,
+        color: user.color,
+        ccfLevel: user.ccfLevel ?? 0,
+        xcpcLevel: user.xcpcLevel ?? 0,
+        prizes
+    }
+    ```
+6. Call `UserService.saveLuoguUserProfile`.
+7. Emit Socket.IO event `user:{uid}:profile-updated` to room `user_{uid}` (no payload).
+8. Return `{ skipNextStep: false, data: { text: '' } }`.
+
+### 5.4 Idempotency
+
+Successive `save:profile` invocations for the same `uid` are idempotent: the row is upserted, `profile_fetched_at` is bumped, and the `prizes` array is replaced wholesale. No history is preserved.
+
+## 6. User Router
+
+Routes are mounted under `/user` and registered in `packages/backend/src/routers/index.ts`.
+
+### 6.1 `GET /user/:id`
+
+Retrieve a stored user profile by Luogu UID.
+
+**Request:**
+
+- Path parameter: `id` (string of digits) - Luogu UID
+
+**Response:**
+
+- 200: `User` object (full row including `prizes`, `profileFetchedAt`, plus a derived boolean `profileStale`)
+- 400: `id` is not a valid positive integer
+- 404: User not in database (i.e., the saver has never observed this user via any content)
+- 500: Server error
+
+**Side Effects:**
+
+- If the user exists in the database AND `isProfileStale(user)` returns `true`, the router MUST dispatch a `save:profile` task for this UID. The task is created via `TaskService.createTask` + `dispatchTask` and is fire-and-forget; the route handler does NOT wait for it to complete.
+- If user does NOT exist in the database, the router MUST NOT dispatch a profile task. (Rationale: a stranger UID could be invalid; we only refresh users the saver has already seen.)
+
+**Response shape:**
+
+```typescript
+{
+    id: number,
+    name: string,
+    color: UserColor,
+    ccfLevel: number,
+    xcpcLevel: number,
+    prizes: UserPrize[] | null,
+    profileFetchedAt: Date | null,
+    profileStale: boolean,
+    createdAt: Date,
+    updatedAt: Date
+}
+```
+
+### 6.2 `POST /user/:id/refresh`
+
+Explicitly trigger a `save:profile` task for the given UID.
+
+**Request:**
+
+- Path parameter: `id` (string of digits) - Luogu UID
+- Body: ignored
+
+**Response:**
+
+- 200: `{ taskId: string }`
+- 400: `id` is not a valid positive integer
+- 500: Server error
+
+**Side Effects:**
+
+- Unconditionally dispatches a `save:profile` task (no staleness check, no requirement that the user already exists).
+
+## 7. Invariants
+
+1. The inline content path (`buildUser` → `upsertLuoguUser`) never writes `prizes` or `profile_fetched_at`.
+2. The profile task path (`ProfileHandler` → `saveLuoguUserProfile`) always writes `prizes` and bumps `profile_fetched_at`.
+3. `ccf_level` and `xcpc_level` are non-null integers with default `0`; missing upstream values map to `0`.
+4. The cache key `user:{id}` is evicted by every write path that touches the row.
+5. A stale profile is served immediately; refresh happens asynchronously and does not block the GET response.
+
+## 8. File Locations
+
+- User entity: `packages/backend/src/entities/user.ts`
+- User color enum: `packages/backend/src/shared/user.ts`
+- `UserPrize` type: `packages/backend/src/shared/user.ts`
+- `PROFILE_TTL_MS` constant: `packages/backend/src/shared/user.ts`
+- `buildUser` helper: `packages/backend/src/utils/luogu-api.ts`
+- `UserService`: `packages/backend/src/services/user.service.ts`
+- Profile handler: `packages/backend/src/workers/handlers/task/save/profile.handler.ts`
+- Handler registration: `packages/backend/src/workers/index.ts`
+- User router: `packages/backend/src/routers/user.router.ts`
+- Router registration: `packages/backend/src/routers/index.ts`

--- a/spec/user-system.spec.md
+++ b/spec/user-system.spec.md
@@ -16,17 +16,20 @@ The system exposes:
 
 Table name: `user`
 
-| Column               | Type         | Constraints           | Description                                         |
-| -------------------- | ------------ | --------------------- | --------------------------------------------------- |
-| `id`                 | INT UNSIGNED | PRIMARY KEY           | Luogu user ID                                       |
-| `name`               | VARCHAR      | NOT NULL              | Luogu user name                                     |
-| `color`              | VARCHAR      | NOT NULL              | Dynamic level color (UserColor enum)                |
-| `ccf_level`          | INT          | NOT NULL, DEFAULT `0` | OI / CCF certification level (`0` = none)           |
-| `xcpc_level`         | INT          | NOT NULL, DEFAULT `0` | ICPC / CCPC certification level (`0` = none)        |
-| `prizes`             | JSON         | NULLABLE              | Array of `UserPrize` records; `NULL` if not fetched |
-| `profile_fetched_at` | DATETIME     | NULLABLE              | Timestamp of the last successful profile fetch      |
-| `created_at`         | DATETIME     | NOT NULL              | Record creation timestamp                           |
-| `updated_at`         | DATETIME     | NOT NULL              | Record update timestamp                             |
+| Column                  | Type         | Constraints           | Description                                                        |
+| ----------------------- | ------------ | --------------------- | ------------------------------------------------------------------ |
+| `id`                    | INT UNSIGNED | PRIMARY KEY           | Luogu user ID                                                      |
+| `name`                  | VARCHAR      | NOT NULL              | Luogu user name                                                    |
+| `color`                 | VARCHAR      | NOT NULL              | Dynamic level color (UserColor enum)                               |
+| `ccf_level`             | INT          | NOT NULL, DEFAULT `0` | OI / CCF certification level (`0` = none)                          |
+| `xcpc_level`            | INT          | NOT NULL, DEFAULT `0` | ICPC / CCPC certification level (`0` = none)                       |
+| `slogan`                | TEXT         | NULLABLE              | Short profile tagline as raw text                                  |
+| `introduction`          | TEXT         | NULLABLE              | Long profile introduction as raw Markdown                          |
+| `rendered_introduction` | TEXT         | NULLABLE              | HTML rendered from `introduction` via the shared markdown pipeline |
+| `prizes`                | JSON         | NULLABLE              | Array of `UserPrize` records; `NULL` if not fetched                |
+| `profile_fetched_at`    | DATETIME     | NULLABLE              | Timestamp of the last successful profile fetch                     |
+| `created_at`            | DATETIME     | NOT NULL              | Record creation timestamp                                          |
+| `updated_at`            | DATETIME     | NOT NULL              | Record update timestamp                                            |
 
 ### 2.2 UserColor Enum
 
@@ -37,12 +40,15 @@ Unchanged from `packages/backend/src/shared/user.ts`. Values: `Gray`, `Blue`, `G
 ```typescript
 interface UserPrize {
     year: number; // Award year, e.g. 2023
-    contestName: string; // Award contest name, free-form string from Luogu
-    prize: string; // Award level/name, free-form string from Luogu
+    contest: string; // Contest name, free-form string from Luogu (e.g. "NOI", "CSP-S")
+    event: string | null; // Contest sub-event, free-form string or null (e.g. "The 2026 Universal Cup Finals")
+    prize: string; // Award level, free-form string from Luogu (e.g. "金牌", "一等奖")
+    score?: number; // Score achieved at the contest, if available
+    rank?: number; // Rank achieved at the contest, if available
 }
 ```
 
-`UserPrize` is stored as one element of the `prizes` JSON array. The shape mirrors the `prize` field in Luogu's `UserDetails` response (`packages/backend/src/types/luogu-api.d.ts`, interface `UserDetails`).
+`UserPrize` is stored as one element of the `prizes` JSON array. The shape mirrors the inner `prize` object inside `response.data.prizes[i].prize` from Luogu's user-page response. See `packages/backend/src/types/luogu-api.d.ts`, interface `LuoguPrize`.
 
 ### 2.4 Level Semantics
 
@@ -77,14 +83,14 @@ Inline content handlers (article, paste) call `UserService.upsertLuoguUser(data)
 }
 ```
 
-`buildUser` MUST NOT touch `prizes` or `profileFetchedAt`. These fields are only written by the profile task handler (Section 5).
+`buildUser` MUST NOT touch `slogan`, `introduction`, `renderedIntroduction`, `prizes`, or `profileFetchedAt`. These fields are only written by the profile task handler (Section 5).
 
 `UserService.upsertLuoguUser`:
 
 1. Requires `data.id` to be defined; throws otherwise.
 2. Performs a TypeORM upsert on the primary key.
 3. Evicts the cache key `user:{id}`.
-4. Does NOT mutate `prizes` or `profile_fetched_at` even if `data` happens to contain them.
+4. Does NOT mutate `slogan`, `introduction`, `renderedIntroduction`, `prizes`, or `profile_fetched_at` even if `data` happens to contain them.
 
 This invariant guarantees that the cheap inline path never clobbers richer data fetched by the profile task.
 
@@ -105,12 +111,12 @@ Same query as `getUserById` but bypasses the cache.
 
 Behavior defined in Section 3.
 
-### 4.4 `saveLuoguUserProfile(data: { uid; name; color; ccfLevel; xcpcLevel; prizes }, manager?): Promise<User>`
+### 4.4 `saveLuoguUserProfile(data: { uid; name; color; ccfLevel; xcpcLevel; slogan; introduction; renderedIntroduction; prizes }, manager?): Promise<User>`
 
 Profile-task write path. MUST:
 
 1. Upsert the user row using the primary key.
-2. Set `ccf_level`, `xcpc_level`, `prizes`, AND `profile_fetched_at = now()` atomically.
+2. Set `ccf_level`, `xcpc_level`, `slogan`, `introduction`, `rendered_introduction`, `prizes`, AND `profile_fetched_at = now()` atomically.
 3. Update `name` and `color` to the incoming values (the profile fetch is authoritative for the moment).
 4. Evict cache key `user:{id}`.
 
@@ -154,8 +160,11 @@ The handler is registered in `packages/backend/src/workers/index.ts` alongside `
 3. Validate that the response has shape `LentilleDataResponse<UserData>`; reject with `UnrecoverableError` otherwise.
 4. Extract:
     - `user: UserDetails` from `response.data.user`
-    - `prizes: UserPrize[]` from `response.data.user.prize` (defensive: default to `[]` if absent or non-array)
-5. Build the payload for `UserService.saveLuoguUserProfile`:
+    - `slogan: string | null` from `response.data.user.slogan`; treat empty strings and non-strings as `null`
+    - `introduction: string | null` from `response.data.user.introduction`; treat empty strings and non-strings as `null`
+    - `prizes: UserPrize[]` from `response.data.prizes`. Each element of `response.data.prizes` is a one-level wrapper `{ prize: LuoguPrize }`; the handler MUST unwrap the inner `prize` object before storing. Despite the name, `response.data.user.prize` is unrelated and may be empty; do NOT read from it. Default to `[]` if `response.data.prizes` is absent or non-array.
+5. If `introduction !== null`, render it via the shared `renderMarkdown` pipeline (`packages/backend/src/lib/markdown.ts`) to produce `renderedIntroduction: string`. Otherwise `renderedIntroduction = null`. The handler does not memoize this; idempotent re-runs re-render.
+6. Build the payload for `UserService.saveLuoguUserProfile`:
     ```typescript
     {
         uid: user.uid,
@@ -163,16 +172,19 @@ The handler is registered in `packages/backend/src/workers/index.ts` alongside `
         color: user.color,
         ccfLevel: user.ccfLevel ?? 0,
         xcpcLevel: user.xcpcLevel ?? 0,
+        slogan,
+        introduction,
+        renderedIntroduction,
         prizes
     }
     ```
-6. Call `UserService.saveLuoguUserProfile`.
-7. Emit Socket.IO event `user:{uid}:profile-updated` to room `user_{uid}` (no payload).
-8. Return `{ skipNextStep: false, data: { text: '' } }`.
+7. Call `UserService.saveLuoguUserProfile`.
+8. Emit Socket.IO event `user:{uid}:profile-updated` to room `user_{uid}` (no payload).
+9. Return `{ skipNextStep: false, data: { text: '' } }`.
 
 ### 5.4 Idempotency
 
-Successive `save:profile` invocations for the same `uid` are idempotent: the row is upserted, `profile_fetched_at` is bumped, and the `prizes` array is replaced wholesale. No history is preserved.
+Successive `save:profile` invocations for the same `uid` are idempotent: the row is upserted, `profile_fetched_at` is bumped, and the `slogan` / `introduction` / `rendered_introduction` / `prizes` fields are replaced wholesale. No history is preserved.
 
 ## 6. User Router
 
@@ -207,6 +219,8 @@ Retrieve a stored user profile by Luogu UID.
     color: UserColor,
     ccfLevel: number,
     xcpcLevel: number,
+    slogan: string | null,
+    renderedIntroduction: string | null,  // HTML; the raw `introduction` is not returned to the client
     prizes: UserPrize[] | null,
     profileFetchedAt: Date | null,
     profileStale: boolean,


### PR DESCRIPTION
为保存站补全奖项认证（OI / ICPC / CCPC）展示功能。

1. 在任何展示用户昵称的位置（plaza、文章详情、剪贴板等），昵称右侧渲染对应的等级徽章
2. 新增用户主页 `/user/:id`，展示用户头像、彩色昵称、徽章、Markdown 渲染的个人介绍，以及完整获奖历史

徽章样式直接采用洛谷主站的 SVG path。