### PR TITLE
fix(profile): return introduction as text payload for save:profile

### DIFF
--- a/packages/backend/src/workers/handlers/task/save/profile.handler.ts
+++ b/packages/backend/src/workers/handlers/task/save/profile.handler.ts
@@ -84,10 +84,14 @@ export class ProfileHandler implements TaskHandler<SaveTask> {
         emitToRoom(`user_${uid}`, `user:${uid}:profile-updated`);
         logger.info({ uid, prizeCount: prizes.length }, 'Profile saved');
 
+        // The text payload mirrors the contract of save:article / save:paste: emit
+        // whatever raw textual content was saved so downstream LLM steps (if any
+        // are wired up later — currently profile is single-step) can consume it.
+        // Slogan is omitted because of low signal value; prize structure is JSON-only.
         return {
             skipNextStep: false,
             data: {
-                text: ''
+                text: introduction ?? ''
             }
         };
     }

--- a/spec/user-system.spec.md
+++ b/spec/user-system.spec.md
@@ -180,7 +180,7 @@ The handler is registered in `packages/backend/src/workers/index.ts` alongside `
     ```
 7. Call `UserService.saveLuoguUserProfile`.
 8. Emit Socket.IO event `user:{uid}:profile-updated` to room `user_{uid}` (no payload).
-9. Return `{ skipNextStep: false, data: { text: '' } }`.
+9. Return `{ skipNextStep: false, data: { text: introduction ?? '' } }`. The handler emits the raw Markdown introduction so that downstream LLM tasks (none exist today; profile refresh is single-step) can consume it via `job.getChildrenValues()`. This mirrors the contract of `save:article` and `save:paste` handlers. Empty string indicates no introduction is set.
 
 ### 5.4 Idempotency
 


### PR DESCRIPTION
Addresses review feedback: save:* handlers conventionally return the raw saved content via TaskTextResult.text.

Returning introduction (raw Markdown) restores that symmetry and unblocks future workflow extensions (e.g. summarizing or embedding user introductions). Slogan is omitted (low signal); prize data is JSON and not text-shaped.