### PR TITLE
feat(about): add About page with project intro, features, stats and sth

### DIFF
--- a/packages/frontend/src/routers/modules/about.ts
+++ b/packages/frontend/src/routers/modules/about.ts
@@ -1,0 +1,12 @@
+import type { RouteRecordRaw } from 'vue-router';
+
+export default [
+    {
+        path: '/about',
+        name: 'about',
+        component: () => import('@/views/about/AboutView.vue'),
+        meta: {
+            activeMenu: 'about'
+        }
+    }
+] as RouteRecordRaw[];

--- a/packages/frontend/src/views/about/AboutView.vue
+++ b/packages/frontend/src/views/about/AboutView.vue
@@ -56,7 +56,7 @@ const features = [
     {
         icon: StatsChartOutline,
         label: 'RAG 问答',
-        desc: '依据交互式 LLM 检索推荐相关内容。'
+        desc: '依据文本生成式 AI 检索推荐相关内容。'
     },
     {
         icon: Clipboard,

--- a/packages/frontend/src/views/about/AboutView.vue
+++ b/packages/frontend/src/views/about/AboutView.vue
@@ -1,0 +1,262 @@
+<script setup lang="ts">
+import { onMounted, ref, inject } from 'vue';
+import { NGrid, NGi, NStatistic, NIcon } from 'naive-ui';
+import {
+    AppsOutline,
+    ListOutline,
+    HammerOutline,
+    StatsChartOutline,
+    GlobeOutline,
+    CloudDownloadOutline,
+    Newspaper,
+    Clipboard,
+    SearchOutline,
+    ShareSocialOutline,
+    AtOutline
+} from '@vicons/ionicons5';
+
+import { getArticleCount } from '@/api/article.ts';
+import { getPasteCount } from '@/api/paste.ts';
+import Card from '@/components/Card.vue';
+import { uiThemeKey } from '@/styles/theme/themeKeys.ts';
+
+const themeVars = inject(uiThemeKey)!;
+
+// MUST equal `foundDate` in App.vue. See spec/about-page.spec.md §3.5 / §6.4.
+const FOUNDING_DATE = new Date('2025-02-12T00:00:00Z').getTime();
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const articleCount = ref(0);
+const pasteCount = ref(0);
+const daysInOperation = ref(Math.floor((Date.now() - FOUNDING_DATE) / MS_PER_DAY));
+
+const REPO_URL = 'https://github.com/Ark-Aak/luogu-saver-next';
+
+const features = [
+    {
+        icon: Newspaper,
+        label: '内容归档',
+        desc: '抓取并长期保存洛谷的文章与剪贴板,即使原内容被删除也可访问。'
+    },
+    {
+        icon: SearchOutline,
+        label: '全文检索',
+        desc: '对已保存的内容建立索引,支持按关键词快速检索。'
+    },
+    {
+        icon: ShareSocialOutline,
+        label: '文章广场',
+        desc: '集中浏览已归档的文章,发现值得阅读的内容。'
+    },
+    {
+        icon: AtOutline,
+        label: '用户主页',
+        desc: '展示用户的等级认证徽章与获奖记录。'
+    },
+    {
+        icon: StatsChartOutline,
+        label: 'RAG 问答',
+        desc: '依据交互式 LLM 检索推荐相关内容。'
+    },
+    {
+        icon: Clipboard,
+        label: '多类型支持',
+        desc: '统一处理多种内容类型，持续扩展中。'
+    }
+];
+
+onMounted(() => {
+    getArticleCount()
+        .then(res => (articleCount.value = res.data.count))
+        .catch(() => {});
+    getPasteCount()
+        .then(res => (pasteCount.value = res.data.count))
+        .catch(() => {});
+});
+</script>
+
+<template>
+    <div class="about-view">
+        <div class="about-header">
+            <h1 class="about-title">关于 Luogu Saver Next</h1>
+            <p class="about-subtitle">一个用于归档洛谷用户生成内容的开源 Web 应用 · LGS-NG</p>
+        </div>
+
+        <Card :icon="AppsOutline" title="项目简介" class="about-card">
+            <p class="about-paragraph">
+                Luogu Saver Next（简称
+                LGS-NG）是一个面向洛谷的内容归档应用。它将洛谷上的文章、剪贴板等用户生成内容抓取并长期保存，使有价值的内容在原始页面被删除或失效后，依然可以被检索与阅读。
+            </p>
+        </Card>
+
+        <Card :icon="StatsChartOutline" title="运行统计" class="about-card">
+            <n-grid :x-gap="20" :y-gap="20" cols="1 s:3" responsive="screen">
+                <n-gi>
+                    <n-statistic label="已运行天数" :value="daysInOperation" />
+                </n-gi>
+                <n-gi>
+                    <n-statistic label="已归档文章" :value="articleCount" />
+                </n-gi>
+                <n-gi>
+                    <n-statistic label="已归档剪贴板" :value="pasteCount" />
+                </n-gi>
+            </n-grid>
+        </Card>
+
+        <Card :icon="ListOutline" title="核心功能" class="about-card">
+            <ul class="feature-list">
+                <li v-for="feature in features" :key="feature.label" class="feature-item">
+                    <n-icon
+                        size="20"
+                        :component="feature.icon"
+                        :color="themeVars.primaryColor"
+                        class="feature-icon"
+                    />
+                    <div class="feature-text">
+                        <span class="feature-label">{{ feature.label }}</span>
+                        <span class="feature-desc">{{ feature.desc }}</span>
+                    </div>
+                </li>
+            </ul>
+        </Card>
+
+        <Card :icon="HammerOutline" title="技术与架构" class="about-card">
+            <p class="about-paragraph">
+                本项目采用 npm workspaces 组织的 Monorepo 结构。前端基于 Vue 3、Vite 与 Naive UI
+                构建；后端基于 Koa 与 TypeScript；数据库等基础设施通过 Docker Compose 管理。项目以
+                AGPL-3.0 许可证开源。
+            </p>
+        </Card>
+
+        <Card :icon="GlobeOutline" title="开源与贡献" class="about-card">
+            <p class="about-paragraph">
+                本项目在 GitHub 上开源，采用 AGPL-3.0 许可证。欢迎通过提交 Pull Request 参与改进。
+            </p>
+            <a
+                class="about-link"
+                :href="REPO_URL"
+                target="_blank"
+                rel="noopener noreferrer"
+                :style="{ color: themeVars.primaryColor }"
+            >
+                <n-icon size="18" :component="GlobeOutline" />
+                <span>{{ REPO_URL }}</span>
+            </a>
+        </Card>
+
+        <Card
+            :icon="CloudDownloadOutline"
+            title="数据来源与免责声明"
+            class="about-card about-card--faint"
+        >
+            <ul class="disclaimer-list">
+                <li>本站归档的全部内容均来源于洛谷，其版权归原作者所有。</li>
+                <li>本项目为非官方归档工具，与洛谷官方无任何隶属或背书关系。</li>
+                <li>如相关权利人提出合理要求，本站将配合移除对应内容。</li>
+            </ul>
+        </Card>
+    </div>
+</template>
+
+<style scoped>
+.about-view {
+    max-width: 880px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.about-header {
+    padding: 8px 4px 0;
+}
+.about-title {
+    margin: 0;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1.3;
+}
+.about-subtitle {
+    margin: 6px 0 0;
+    color: var(--n-text-color-3, #999);
+    font-size: 14px;
+}
+
+.about-card {
+    width: 100%;
+}
+
+.about-paragraph {
+    margin: 0;
+    line-height: 1.8;
+    font-size: 15px;
+    color: var(--n-text-color-1, #333);
+}
+
+.feature-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 14px;
+}
+@media (min-width: 640px) {
+    .feature-list {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+.feature-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+}
+.feature-icon {
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+.feature-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+}
+.feature-label {
+    font-weight: 600;
+    font-size: 14px;
+}
+.feature-desc {
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--n-text-color-2, #666);
+}
+
+.about-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 12px;
+    font-size: 14px;
+    word-break: break-all;
+    text-decoration: none;
+}
+.about-link:hover {
+    text-decoration: underline;
+}
+
+.about-card--faint {
+    opacity: 0.85;
+}
+.disclaimer-list {
+    margin: 0;
+    padding-left: 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.disclaimer-list li {
+    font-size: 13px;
+    line-height: 1.7;
+    color: var(--n-text-color-2, #666);
+}
+</style>

--- a/spec/about-page.spec.md
+++ b/spec/about-page.spec.md
@@ -1,0 +1,90 @@
+# About Page Specification
+
+## 1. Overview
+
+The About page is a static, read-only informational page served by the frontend at `/about`. It introduces the project, enumerates its features, states the technology stack, surfaces live runtime statistics, links to the open-source repository, and presents a data-source and disclaimer notice.
+
+The page introduces NO new backend endpoints, NO new database tables, and NO new shared types. It reuses existing public count endpoints for its statistics section. All other content is static text rendered client-side.
+
+The navigation entry already exists in `App.vue` (`menuOptions`, key `about`); selecting it invokes `router.push('/about')`. Prior to this page, that route resolved to the catch-all `NotFound` view. This specification defines the route and view that satisfy the existing entry.
+
+## 2. Route
+
+A single route is registered through the frontend router module auto-loader (`packages/frontend/src/routers/index.ts`, which globs `./modules/*.ts`).
+
+| Property          | Value                                       |
+| ----------------- | ------------------------------------------- |
+| `path`            | `/about`                                    |
+| `name`            | `about`                                     |
+| `component`       | `@/views/about/AboutView.vue` (lazy-loaded) |
+| `meta.activeMenu` | `about`                                     |
+
+`meta.activeMenu` MUST equal `about` so the sidebar highlights the matching menu entry, consistent with the `App.vue` active-menu computation.
+
+## 3. Page Sections
+
+The view SHALL render the following sections, in this order. Section copy is in Simplified Chinese with a formal, documentation-style register.
+
+### 3.1 Header
+
+A page title and a one-line subtitle identifying the project as Luogu Saver Next (LGS-NG).
+
+### 3.2 Project Introduction (项目简介)
+
+A prose description: LGS-NG is a web application for archiving user-generated content (articles, pastes, and related content) from Luogu, so that valuable content remains accessible even if the original is deleted.
+
+### 3.3 Core Features (核心功能)
+
+A list of the application's user-facing capabilities. Each item has a short label and a one-line description. The set is sourced from the live navigation menu and MUST remain a superset accurate to shipped functionality; at minimum it includes content archiving (articles and pastes), full-text search, the article plaza, user profiles, and intelligent recommendations.
+
+### 3.4 Technology & Architecture (技术与架构)
+
+A concise statement of the stack: a npm-workspaces monorepo; a Vue 3 + Vite + Naive UI frontend; a Koa + TypeScript backend; supporting infrastructure managed via Docker Compose. The project is released under the AGPL-3.0 license.
+
+### 3.5 Runtime Statistics (运行统计)
+
+Three live figures:
+
+1. **Days in operation** — computed client-side as `floor((now - FOUNDING_DATE) / 1 day)`, where `FOUNDING_DATE` is `2025-02-12T00:00:00Z`. This constant mirrors `foundDate` in `App.vue`; the two MUST stay equal.
+2. **Total archived articles** — from `GET /article/count` via `getArticleCount()`.
+3. **Total archived pastes** — from `GET /paste/count` via `getPasteCount()`.
+
+Both counts default to `0` before their requests resolve. Request failures are non-fatal: the affected figure remains `0` and no error is surfaced to the user. The statistics section MUST render even if both requests fail.
+
+### 3.6 Open Source & Contribution (开源与贡献)
+
+A link to the GitHub repository (`https://github.com/Ark-Aak/luogu-saver-next`), a statement of the AGPL-3.0 license, and a short invitation to contribute via pull request. External links MUST open in a new tab with `rel="noopener noreferrer"`.
+
+### 3.7 Data Source & Disclaimer (数据来源与免责声明)
+
+A notice stating that:
+
+1. All archived content originates from Luogu and its copyright belongs to the respective original authors.
+2. This project is an unofficial archive and is not affiliated with or endorsed by Luogu.
+3. Content may be removed upon a legitimate request from the rights holder.
+
+This section is rendered last and styled with reduced visual emphasis.
+
+## 4. Data Sources
+
+The page consumes only the following existing endpoints; it MUST NOT introduce new ones:
+
+- `GET /article/count` → `{ count: number }` (via `getArticleCount`)
+- `GET /paste/count` → `{ count: number }` (via `getPasteCount`)
+
+The founding date is a frontend constant, not a server value.
+
+## 5. Layout & Styling
+
+- The view reuses the shared `Card` component (`@/components/Card.vue`) for each section, consistent with `HomeView`.
+- The runtime statistics use Naive UI `NStatistic` inside a responsive `NGrid`.
+- The layout is a single vertical column of cards on all breakpoints, with the statistics figures arranged horizontally within their card and collapsing to fewer columns on narrow screens.
+- Colors derive from the injected theme variables (`uiThemeKey`), never hard-coded brand colors, matching the rest of the application.
+
+## 6. Invariants
+
+1. The page is purely presentational: it triggers only idempotent GET requests and mutates no server state.
+2. No authentication is required; the page is accessible to anonymous visitors.
+3. The page MUST render fully even when both count requests fail.
+4. `FOUNDING_DATE` in the view MUST equal `foundDate` in `App.vue`.
+5. The route's `meta.activeMenu` MUST equal `about`.


### PR DESCRIPTION
…isclaimer

Implements the long-reserved 'about' menu entry (App.vue menuOptions) that previously fell through to the NotFound view.

- New /about route (auto-registered via the router module glob)
- AboutView with six sections: project intro, runtime statistics, core features, tech stack, open-source/contribution, data source & disclaimer
- Runtime statistics reuse the existing GET /article/count and GET /paste/count endpoints; no new backend or DB changes
- Days-in-operation derived from a frontend FOUNDING_DATE constant that mirrors App.vue's foundDate
- New spec/about-page.spec.md documents the page contract (spec-first per AGENTS.md)