### PR TITLE
feat(legal): add privacy, disclaimer and deletion pages

### DIFF
--- a/packages/frontend/src/App.vue
+++ b/packages/frontend/src/App.vue
@@ -133,24 +133,27 @@
                                                     </a>
                                                 </p>
                                                 <p class="footer-element right-aligned">
-                                                    <a href="/privacy" class="footer-link">
+                                                    <router-link to="/privacy" class="footer-link">
                                                         <Icon>
                                                             <UserShield />
                                                         </Icon>
                                                         <span>隐私协议</span>
-                                                    </a>
-                                                    <a href="/disclaimer" class="footer-link">
+                                                    </router-link>
+                                                    <router-link
+                                                        to="/disclaimer"
+                                                        class="footer-link"
+                                                    >
                                                         <Icon>
                                                             <ExclamationCircle />
                                                         </Icon>
                                                         <span>免责声明</span>
-                                                    </a>
-                                                    <a href="/deletion" class="footer-link">
+                                                    </router-link>
+                                                    <router-link to="/deletion" class="footer-link">
                                                         <Icon>
                                                             <TrashAlt />
                                                         </Icon>
                                                         <span>数据移除政策</span>
-                                                    </a>
+                                                    </router-link>
                                                 </p>
                                                 <p class="footer-element right-aligned">
                                                     <a

--- a/packages/frontend/src/routers/modules/legal.ts
+++ b/packages/frontend/src/routers/modules/legal.ts
@@ -1,0 +1,31 @@
+import type { RouteRecordRaw } from 'vue-router';
+
+export default [
+    {
+        path: '/privacy',
+        name: 'privacy',
+        component: () => import('@/views/legal/LegalView.vue'),
+        props: { docKey: 'privacy' },
+        meta: {
+            activeMenu: ''
+        }
+    },
+    {
+        path: '/disclaimer',
+        name: 'disclaimer',
+        component: () => import('@/views/legal/LegalView.vue'),
+        props: { docKey: 'disclaimer' },
+        meta: {
+            activeMenu: ''
+        }
+    },
+    {
+        path: '/deletion',
+        name: 'deletion',
+        component: () => import('@/views/legal/LegalView.vue'),
+        props: { docKey: 'deletion' },
+        meta: {
+            activeMenu: ''
+        }
+    }
+] as RouteRecordRaw[];

--- a/packages/frontend/src/views/legal/LegalView.vue
+++ b/packages/frontend/src/views/legal/LegalView.vue
@@ -1,0 +1,132 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Icon } from '@vicons/utils';
+import { UserShield, ExclamationCircle, TrashAlt } from '@vicons/fa';
+
+import Card from '@/components/Card.vue';
+import { LEGAL_DOCUMENTS, type LegalKey } from '@/views/legal/legal-content.ts';
+
+const props = defineProps<{
+    docKey: LegalKey;
+}>();
+
+const doc = computed(() => LEGAL_DOCUMENTS[props.docKey]);
+
+const ICON_MAP = {
+    privacy: UserShield,
+    disclaimer: ExclamationCircle,
+    deletion: TrashAlt
+} as const;
+
+const iconComponent = computed(() => ICON_MAP[doc.value.icon]);
+</script>
+
+<template>
+    <div class="legal-view">
+        <Card class="legal-card">
+            <div class="legal-header">
+                <span class="legal-icon">
+                    <Icon>
+                        <component :is="iconComponent" />
+                    </Icon>
+                </span>
+                <div class="legal-header-text">
+                    <h1 class="legal-title">{{ doc.title }}</h1>
+                    <p class="legal-updated">最后更新于：{{ doc.updatedAt }}</p>
+                </div>
+            </div>
+        </Card>
+
+        <Card class="legal-card">
+            <section v-for="section in doc.sections" :key="section.heading" class="legal-section">
+                <h3 class="legal-heading">{{ section.heading }}</h3>
+                <template v-for="(seg, idx) in section.segments" :key="idx">
+                    <!-- Content is a hard-coded static constant (legal-content.ts),
+                         not user input; v-html is safe here. -->
+                    <!-- eslint-disable-next-line vue/no-v-html -->
+                    <p
+                        v-if="seg.kind === 'paragraph'"
+                        class="legal-paragraph"
+                        v-html="seg.html"
+                    ></p>
+                    <ul v-else class="legal-list">
+                        <!-- eslint-disable-next-line vue/no-v-html -->
+                        <li v-for="(item, i) in seg.items" :key="i" v-html="item"></li>
+                    </ul>
+                </template>
+            </section>
+        </Card>
+    </div>
+</template>
+
+<style scoped>
+.legal-view {
+    max-width: 880px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.legal-header {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+}
+.legal-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 28px;
+    color: var(--n-primary-color, #2f6db5);
+    flex-shrink: 0;
+}
+.legal-header-text {
+    min-width: 0;
+}
+.legal-title {
+    margin: 0;
+    font-size: 24px;
+    font-weight: 700;
+    line-height: 1.3;
+}
+.legal-updated {
+    margin: 4px 0 0;
+    font-size: 13px;
+    color: var(--n-text-color-3, #999);
+}
+
+.legal-section {
+    margin-bottom: 22px;
+}
+.legal-section:last-child {
+    margin-bottom: 0;
+}
+.legal-heading {
+    margin: 0 0 10px;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.4;
+}
+.legal-paragraph {
+    margin: 0;
+    line-height: 1.8;
+    font-size: 14px;
+    color: var(--n-text-color-1, #333);
+}
+.legal-list {
+    margin: 0;
+    padding-left: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.legal-list li {
+    line-height: 1.8;
+    font-size: 14px;
+    color: var(--n-text-color-1, #333);
+}
+.legal-paragraph + .legal-list {
+    margin-top: 10px;
+}
+</style>

--- a/packages/frontend/src/views/legal/legal-content.ts
+++ b/packages/frontend/src/views/legal/legal-content.ts
@@ -1,0 +1,276 @@
+// Legal page content, ported from the predecessor project laikit-dev/luogu-saver
+// (views/legal/*.njk). Content is authoritative Simplified Chinese legal text and
+// should be edited with care. Structure is data-driven so all three pages share a
+// single renderer (LegalView.vue).
+
+export type LegalSegment = { kind: 'paragraph'; html: string } | { kind: 'list'; items: string[] };
+
+export interface LegalSection {
+    heading: string;
+    segments: LegalSegment[];
+}
+
+export interface LegalDocument {
+    // icon name resolved by the view against a fixed allow-list
+    icon: 'privacy' | 'disclaimer' | 'deletion';
+    title: string;
+    updatedAt: string;
+    sections: LegalSection[];
+}
+
+export type LegalKey = 'privacy' | 'disclaimer' | 'deletion';
+
+export const LEGAL_DOCUMENTS: Record<LegalKey, LegalDocument> = {
+    privacy: {
+        icon: 'privacy',
+        title: '隐私协议',
+        updatedAt: '2025 年 8 月 20 日',
+        sections: [
+            {
+                heading: '一、信息收集',
+                segments: [
+                    {
+                        kind: 'list',
+                        items: [
+                            '本网站存储并展示来自 <strong>洛谷平台公开的剪贴板和专栏内容</strong>。',
+                            '通过核验用户指定的洛谷剪贴板内容确认身份，并<strong>仅为本站生成登录凭据</strong>，该凭据仅在本站内部使用，不会影响或替代用户的洛谷账号凭据。',
+                            '本网站服务器日志可能记录包括 <strong>IP 地址、访问时间、浏览器信息</strong> 在内的常规访问记录,用于安全与审计目的。',
+                            '除提供服务所必需的数据外，我们不主动收集额外个人信息。'
+                        ]
+                    }
+                ]
+            },
+            {
+                heading: '二、信息使用',
+                segments: [
+                    {
+                        kind: 'list',
+                        items: [
+                            '用于身份验证、提供存储与展示功能、站点安全审计与服务改进。',
+                            '日志信息（如 IP 地址）主要用于防止滥用、保障安全和排查故障。',
+                            '不会将数据用于与本服务无关的用途。'
+                        ]
+                    }
+                ]
+            },
+            {
+                heading: '三、信息公开与共享',
+                segments: [
+                    {
+                        kind: 'list',
+                        items: [
+                            '自洛谷获取的内容为 <strong>公开信息</strong>，因此会在本站被存储与展示。',
+                            '不向第三方出售或出租个人信息；在法律法规或行政 / 司法机关合法要求时，可能提供必要信息。'
+                        ]
+                    }
+                ]
+            },
+            {
+                heading: '四、Cookie 与本地存储',
+                segments: [
+                    {
+                        kind: 'list',
+                        items: [
+                            '本站可能使用 Cookie 或本地存储保存登录 Token 或会话信息，以维持登录状态与安全风控。',
+                            '您可以在浏览器中清除这些数据，但可能导致需要重新登录。'
+                        ]
+                    }
+                ]
+            },
+            {
+                heading: '五、信息安全',
+                segments: [
+                    {
+                        kind: 'list',
+                        items: [
+                            '我们采取合理的安全措施（如 HTTPS、Token 校验、最小化权限）保护数据安全。',
+                            'Token 仅代表<strong>访问授权</strong>,请妥善保管，不与他人共享；如发现泄露请及时重置或联系我们。',
+                            '受限于网络传输与技术环境，无法保证绝对安全。'
+                        ]
+                    }
+                ]
+            },
+            {
+                heading: '六、数据保留与删除',
+                segments: [
+                    {
+                        kind: 'list',
+                        items: [
+                            '公开内容的存档为提供服务之目的而保留；当源站（洛谷）删除或变更内容时，本站不保证同步时效。',
+                            '您可就与您相关的存档提出删除或更正请求，我们将在核实后处理。'
+                        ]
+                    }
+                ]
+            },
+            {
+                heading: '七、跨境传输',
+                segments: [
+                    {
+                        kind: 'paragraph',
+                        html: '根据服务部署情况，数据可能在不同地区的服务器间传输与存储，并适用相应法律法规。'
+                    }
+                ]
+            },
+            {
+                heading: '八、协议更新',
+                segments: [
+                    {
+                        kind: 'paragraph',
+                        html: '我们可能适时更新本隐私协议，并在本页公示，更新后自发布之日起生效。'
+                    }
+                ]
+            }
+        ]
+    },
+    disclaimer: {
+        icon: 'disclaimer',
+        title: '免责声明',
+        updatedAt: '2025 年 8 月 16 日',
+        sections: [
+            {
+                heading: '一、内容来源说明',
+                segments: [
+                    {
+                        kind: 'paragraph',
+                        html: '本网站存储和展示的剪贴板、专栏等内容均来源于 <strong>洛谷平台公开信息</strong>，仅用于归档与索引,不代表本网站观点或立场。'
+                    }
+                ]
+            },
+            {
+                heading: '二、内容的真实性与合法性',
+                segments: [
+                    {
+                        kind: 'paragraph',
+                        html: '本网站不对所存储内容的真实性、完整性、合法性或时效性作出保证。用户应自行判断并承担使用相关内容的风险。'
+                    }
+                ]
+            },
+            {
+                heading: '三、知识产权',
+                segments: [
+                    {
+                        kind: 'list',
+                        items: [
+                            '内容版权归原作者或权利人所有。',
+                            '如您认为本网站存档内容侵犯了您的合法权益，请通过本网站联系方式提交权利通知；我们将在核实后采取删除、屏蔽或断开链接等合理措施。'
+                        ]
+                    }
+                ]
+            },
+            {
+                heading: '四、服务可用性',
+                segments: [
+                    {
+                        kind: 'list',
+                        items: [
+                            '我们致力于提供稳定服务，但不保证服务不中断或无错误，也不对因维护、升级、网络故障、黑客攻击、不可抗力等造成的中断或数据损失承担责任。',
+                            '对源站（洛谷）内容的变更、删除或错误导致的检索异常或失效，本站不承担责任。'
+                        ]
+                    }
+                ]
+            },
+            {
+                heading: '五、用户责任',
+                segments: [
+                    {
+                        kind: 'list',
+                        items: [
+                            '用户在使用本网站服务时应遵守适用的法律法规与平台规则，不得利用本网站实施违法、侵权或不当行为。',
+                            '由于用户自身保管不当造成的 Token 泄露、账户被冒用等损失，<strong>由用户自行承担</strong>。'
+                        ]
+                    }
+                ]
+            },
+            {
+                heading: '六、责任限制',
+                segments: [
+                    {
+                        kind: 'paragraph',
+                        html: '在法律允许范围内，因使用或无法使用本网站服务而造成的任何直接、间接、附带或衍生损失，本网站及其运营者不承担赔偿责任。'
+                    }
+                ]
+            },
+            {
+                heading: '七、条款更新',
+                segments: [
+                    {
+                        kind: 'paragraph',
+                        html: '我们可能适时更新本免责声明，并在本页公示，更新后自发布之日起生效。'
+                    }
+                ]
+            }
+        ]
+    },
+    deletion: {
+        icon: 'deletion',
+        title: '数据移除政策',
+        updatedAt: '2025 年 8 月 16 日',
+        sections: [
+            {
+                heading: '一、移除请求的范围',
+                segments: [
+                    {
+                        kind: 'paragraph',
+                        html: '用户无法自行在本网站直接删除已发布的内容。如需移除内容，须通过联系方式联系我们提交申请。若无特殊情况，申请后删除的形式为<strong>软删除</strong>。'
+                    }
+                ]
+            },
+            {
+                heading: '二、硬删除申请',
+                segments: [
+                    {
+                        kind: 'paragraph',
+                        html: '在以下情形下，用户可提出<strong>硬删除</strong>的申请：'
+                    },
+                    {
+                        kind: 'list',
+                        items: [
+                            '内容涉嫌侵犯第三方合法权益，包括但不限于隐私权、名誉权及著作权；',
+                            '内容涉及违法、违规信息，或违反公序良俗；',
+                            '其他经本网站合理认定确有必要永久删除的情形。'
+                        ]
+                    }
+                ]
+            },
+            {
+                heading: '三、主动移除',
+                segments: [
+                    {
+                        kind: 'paragraph',
+                        html: '本网站有权在无需用户事先同意的情况下，直接删除或屏蔽以下内容：'
+                    },
+                    {
+                        kind: 'list',
+                        items: [
+                            '违反法律法规、政策规定或司法、行政机关要求的；',
+                            '含有恶意攻击、垃圾信息、低俗或其他不当内容的；',
+                            '经举报并确认存在侵权、违法或损害第三方权益的；',
+                            '本网站认为确有必要采取删除措施的其他情形。'
+                        ]
+                    }
+                ]
+            },
+            {
+                heading: '四、数据残留说明',
+                segments: [
+                    {
+                        kind: 'list',
+                        items: [
+                            '<strong>软删除</strong>：本网站可能对部分内容实施标记性删除，即该内容不再对外公开展示，且无法被保存，但在数据库中仍可能被保留，以满足审计、安全与合规的合理需求。',
+                            '<strong>硬删除</strong>：相关数据将在数据库层面予以彻底移除。但受限于技术条件，相关数据在缓存、日志及系统备份中可能会在一定期限内继续存在，直至完成自动覆盖或清理。本网站将在合理范围内采取措施，最大限度减少残留。'
+                        ]
+                    }
+                ]
+            },
+            {
+                heading: '五、协议更新',
+                segments: [
+                    {
+                        kind: 'paragraph',
+                        html: '我们可能适时更新本政策，并在本页公示，更新后自发布之日起生效。'
+                    }
+                ]
+            }
+        ]
+    }
+};

--- a/spec/legal-pages.spec.md
+++ b/spec/legal-pages.spec.md
@@ -1,0 +1,54 @@
+# Legal Pages Specification
+
+## 1. Overview
+
+The legal pages are static, read-only informational pages served by the frontend at `/privacy`, `/disclaimer`, and `/deletion`. They present, respectively, the privacy agreement (隐私协议), the disclaimer (免责声明), and the data deletion policy (数据移除政策).
+
+The pages introduce NO new backend endpoints, NO new database tables, and NO new shared types. All content is static Simplified Chinese legal text rendered client-side. The text is ported from the predecessor project `laikit-dev/luogu-saver` (`views/legal/*.njk`).
+
+The footer in `App.vue` already links to `/privacy`, `/disclaimer`, and `/deletion`. Before these pages existed, those links were plain `<a href>` elements that triggered full-page navigation and resolved to the catch-all `NotFound` view. This specification defines the routes and view that satisfy the existing footer links, and requires the footer links to use client-side `<router-link>` navigation.
+
+## 2. Content Source
+
+All legal text lives in a single data module `packages/frontend/src/views/legal/legal-content.ts`, which exports `LEGAL_DOCUMENTS: Record<LegalKey, LegalDocument>` where `LegalKey` is `'privacy' | 'disclaimer' | 'deletion'`.
+
+Each `LegalDocument` has:
+
+- `icon`: one of `'privacy' | 'disclaimer' | 'deletion'`, resolved by the view to a fixed icon component.
+- `title`: the page title.
+- `updatedAt`: a human-readable last-updated date string.
+- `sections`: an ordered list of `{ heading, segments }`, where each segment is either a `paragraph` (single HTML string) or a `list` (array of HTML strings).
+
+Segment HTML may contain inline emphasis markup (e.g. `<strong>`). This HTML is a hard-coded static constant, never user input, and is rendered via `v-html`; this is the only sanctioned `v-html` usage for these pages.
+
+## 3. Routes
+
+Three routes are registered through the frontend router module auto-loader (`packages/frontend/src/routers/index.ts`, which globs `./modules/*.ts`). All three resolve to the same component, differing only by a static `props.docKey`.
+
+| Path          | Name         | `props.docKey` | `meta.activeMenu` |
+| ------------- | ------------ | -------------- | ----------------- |
+| `/privacy`    | `privacy`    | `privacy`      | `''`              |
+| `/disclaimer` | `disclaimer` | `disclaimer`   | `''`              |
+| `/deletion`   | `deletion`   | `deletion`     | `''`              |
+
+`meta.activeMenu` is the empty string because these pages are reached from the footer, not the primary sidebar menu, and therefore highlight no menu entry.
+
+## 4. View
+
+A single component `packages/frontend/src/views/legal/LegalView.vue` renders any legal document.
+
+- It accepts one prop, `docKey: LegalKey`, supplied by the route's static `props`.
+- It looks up `LEGAL_DOCUMENTS[docKey]` and renders a header card (icon, title, last-updated date) followed by a body card containing each section's heading and segments.
+- The icon is selected from a fixed allow-list: `privacy → UserShield`, `disclaimer → ExclamationCircle`, `deletion → TrashAlt` (all from `@vicons/fa`, wrapped with `@vicons/utils` `Icon`), matching the icons already used by the footer links.
+- The layout reuses the shared `Card` component and theme variables, consistent with `AboutView`.
+
+## 5. Footer Integration
+
+The three footer links in `App.vue` MUST use `<router-link :to="...">` rather than `<a href="...">`, so navigation stays within the SPA and does not trigger a full-page reload. Their visible labels and icons are unchanged.
+
+## 6. Invariants
+
+1. The pages are purely presentational: they trigger no network requests and mutate no state.
+2. No authentication is required; the pages are accessible to anonymous visitors.
+3. The three routes share exactly one view component; adding a fourth legal page requires only a new `LEGAL_DOCUMENTS` entry plus a new route.
+4. `v-html` is used solely to render the static, trusted strings in `legal-content.ts`.


### PR DESCRIPTION
Implements the three legal pages already linked from the footer (previously plain <a href> resolving to NotFound). Content ported from the predecessor project laikit-dev/luogu-saver.

- Single data module (legal-content.ts) drives all three pages
- One shared LegalView component, three routes differing only by props.docKey
- Footer links switched from <a href> to <router-link> for SPA navigation
- New spec/legal-pages.spec.md (spec-first per AGENTS.md)