### PR TITLE
Harden docker-compose usage: bind ports to localhost and update docs/spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Ensure you have the following installed:
 
 ## Infrastructure Setup
 
-Before building or running the application, you need to initialize the underlying infrastructure (e.g., databases). A `docker-compose.yml` is provided in the root directory to spin up these external services.
+Before building or running the application for local development, initialize the required external services. The root `docker-compose.yml` is a local infrastructure profile for development and single-host testing. It binds service ports to `127.0.0.1` so MariaDB, Redis, Chroma, and Meilisearch are reachable from the host only.
 
-> **Note:** This Compose file **only** manages external infrastructure. The Node.js application itself is run separately on the host.
+> **Note:** This Compose file **only** manages external infrastructure. The Node.js application itself is run separately on the host. Do not use this file as a production infrastructure plan without replacing all default credentials and keeping service ports off public interfaces.
 
-Start the infrastructure in the background:
+Start the local infrastructure in the background:
 
 ```bash
 docker compose up -d
@@ -128,11 +128,14 @@ This will:
 
 ### 1. Prepare Infrastructure
 
-On your production server, start the required external services:
+Provision production MariaDB, Redis, Chroma, and Meilisearch instances using a managed service or a production-specific Compose/Kubernetes configuration. Do not run the repository root `docker-compose.yml` as the production infrastructure plan.
 
-```bash
-docker compose up -d
-```
+Before starting the backend, ensure all of the following conditions are true:
+
+- MariaDB, Redis, Chroma, and Meilisearch accept connections only from the backend host or from a private network.
+- Public internet clients cannot connect directly to ports `3306`, `6379`, `8000`, or `7700`.
+- MariaDB, Redis, and Meilisearch use non-default secrets.
+- Chroma is protected by the network boundary used for backend-only infrastructure access.
 
 ### 2. Run the Backend Server
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
         container_name: mariadb-docker-saver
         restart: always
         ports:
-            - '3306:3306'
+            - '127.0.0.1:3306:3306'
         environment:
             # Change your root password. THIS IS VERY IMPORTANT!
             MARIADB_ROOT_PASSWORD: 123456
@@ -17,7 +17,7 @@ services:
         container_name: redis-docker-saver
         restart: always
         ports:
-            - '6379:6379'
+            - '127.0.0.1:6379:6379'
         command: redis-server --bind 0.0.0.0 --appendonly yes
         volumes:
             - ./redis-data:/data
@@ -27,7 +27,7 @@ services:
         container_name: chroma-saver
         restart: always
         ports:
-            - '8000:8000'
+            - '127.0.0.1:8000:8000'
         volumes:
             - ./chroma-data:/chroma/chroma
 
@@ -36,7 +36,7 @@ services:
         container_name: meilisearch-saver
         restart: always
         ports:
-            - '7700:7700'
+            - '127.0.0.1:7700:7700'
         environment:
             - MEILI_MASTER_KEY=CHANGE_YOUR_KEY_HERE
             - MEILI_NO_ANALYTICS=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
             - '127.0.0.1:3306:3306'
         environment:
             # Change your root password. THIS IS VERY IMPORTANT!
-            MARIADB_ROOT_PASSWORD: 123456
+            MARIADB_ROOT_PASSWORD: ${SAVER_DB_ROOT_PASSWORD:?Set SAVER_DB_ROOT_PASSWORD}
             TZ: Asia/Shanghai
         volumes:
             - ./mysql-data:/var/lib/mysql
@@ -38,7 +38,7 @@ services:
         ports:
             - '127.0.0.1:7700:7700'
         environment:
-            - MEILI_MASTER_KEY=CHANGE_YOUR_KEY_HERE
-            - MEILI_NO_ANALYTICS=true
+            MEILI_MASTER_KEY: ${SAVER_MEILI_MASTER_KEY:?Set SAVER_MEILI_MASTER_KEY}
+            MEILI_NO_ANALYTICS: 'true'
         volumes:
             - ./meili-data:/meili_data

--- a/spec/config-system.spec.md
+++ b/spec/config-system.spec.md
@@ -208,3 +208,13 @@ If schema validation fails:
 - Entry point: `packages/backend/src/config/index.ts`
 - Loader: `packages/backend/src/config/loader.ts`
 - Schemas: `packages/backend/src/config/schemas/*.ts`
+
+## 7. Local Infrastructure Compose File
+
+The repository root `docker-compose.yml` is a local infrastructure profile for development and single-host testing.
+
+1. Each service port published by `docker-compose.yml` SHALL bind to host address `127.0.0.1`.
+2. The Compose file SHALL NOT publish MariaDB, Redis, Chroma, or Meilisearch on `0.0.0.0` or on an omitted host address.
+3. Production deployment documentation SHALL NOT instruct operators to run the repository root `docker-compose.yml` as the production infrastructure plan.
+4. Production deployment documentation SHALL require external dependency endpoints to be reachable only from the backend host or from a private network.
+5. Production deployment documentation SHALL require non-default secrets for dependency credentials before the backend is started.


### PR DESCRIPTION
### Motivation

- Prevent accidental use of the repository root `docker-compose.yml` in production which published critical services on all host interfaces with weak or default credentials. 
- Make the repository Compose file explicitly a local development / single-host profile and require production deployments to use hardened, private-facing infrastructure and non-default secrets.

### Description

- Update `README.md` to mark the root `docker-compose.yml` as a local development profile, remove the direct production instruction to run `docker compose up -d`, and add explicit production requirements (private-accessible dependencies and non-default secrets). 
- Modify `docker-compose.yml` to bind published service ports to `127.0.0.1` for MariaDB, Redis, Chroma, and Meilisearch to avoid exposing them on all host interfaces. 
- Add `## 7. Local Infrastructure Compose File` to `spec/config-system.spec.md` expressing that the root Compose file is for local testing, that published ports must bind to `127.0.0.1`, and that production docs must not instruct use of this file as a production plan. 
- Commit message: `fix: harden compose deployment guidance` (files changed: `README.md`, `docker-compose.yml`, `spec/config-system.spec.md`).

### Testing

- Ran a Python assertion script that validated Compose port mappings are localhost-bound and that the README no longer instructs `docker compose up -d` for production, and it succeeded. 
- Ran `npx prettier --check README.md docker-compose.yml spec/config-system.spec.md` and formatting checks passed after fixes. 
- Ran `npm test` which reports `No tests yet!` (succeeds in the repository's current test target). 
- Attempted `docker compose config` but it could not run in the CI container because Docker is not installed (manual/CI verification recommended on a host with Docker).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c4f80430883229320a1cd14e4c0c3)