### PR TITLE
fix: do not trust forwarded IP headers

### DIFF
--- a/packages/backend/src/middlewares/client-ip.ts
+++ b/packages/backend/src/middlewares/client-ip.ts
@@ -1,19 +1,5 @@
 import { Context } from 'koa';
 
-function firstHeaderValue(value: string | string[] | undefined): string | null {
-    if (Array.isArray(value)) {
-        return value[0]?.trim() || null;
-    }
-    return value?.trim() || null;
-}
-
 export function getClientIp(ctx: Context): string {
-    const cloudflareIp = firstHeaderValue(ctx.headers['cf-connecting-ip']);
-    if (cloudflareIp) return cloudflareIp;
-
-    const forwardedFor = firstHeaderValue(ctx.headers['x-forwarded-for']);
-    const forwardedIp = forwardedFor?.split(',')[0]?.trim();
-    if (forwardedIp) return forwardedIp;
-
     return ctx.ip;
 }

--- a/spec/api-middleware.spec.md
+++ b/spec/api-middleware.spec.md
@@ -8,11 +8,9 @@ The API middleware subsystem applies HTTP request preprocessing and postprocessi
 
 For every HTTP request, after authorization middleware has completed, the system SHALL write exactly one info-level log entry.
 
-The client IP address SHALL be resolved by this ordered rule set:
+The client IP address SHALL be Koa `ctx.ip`.
 
-1. If request header `cf-connecting-ip` exists and its first value is a non-empty string, use that value.
-2. Else if request header `x-forwarded-for` exists and its first comma-separated item is a non-empty string, use that first item after trimming whitespace.
-3. Else use Koa `ctx.ip`.
+The client IP resolution rule SHALL NOT read request header `cf-connecting-ip`, request header `x-forwarded-for`, or any other forwarding header.
 
 The access log entry SHALL include:
 


### PR DESCRIPTION
### Motivation

- A previous change made `getClientIp` prefer `cf-connecting-ip` and `x-forwarded-for`, which allows unauthenticated clients to spoof the IP used for global rate limiting and access logs. 
- The intent of this patch is to close that attack vector by forcing server-side IP resolution to use the actual socket-derived address instead of client-supplied forwarding headers. 

### Description

- Update `packages/backend/src/middlewares/client-ip.ts` so `getClientIp` returns only `ctx.ip` and no longer reads `cf-connecting-ip`, `x-forwarded-for`, or other request headers. 
- Update `spec/api-middleware.spec.md` to require that the client IP address SHALL be Koa `ctx.ip` and SHALL NOT read forwarding headers, keeping spec and implementation aligned. 
- This change prevents attacker-controlled headers from selecting Redis rate-limit keys or poisoning access log `ip` fields while preserving existing middleware behavior and interfaces. 

### Testing

- Ran `git diff --check` and static assertions that validate `packages/backend/src/middlewares/client-ip.ts` does not reference `ctx.headers`, `cf-connecting-ip`, or `x-forwarded-for`, and that `spec/api-middleware.spec.md` requires `ctx.ip`, and these checks passed. 
- Ran `npm test` which prints the repository test placeholder and passed. 
- Attempted `npm install` which failed due to an external `onnxruntime-node` postinstall network/DNS error (`EAI_AGAIN` resolving `github.com`), so workspace dependencies were not fully installed and no further runtime tests could be executed. 
- Attempted `npm run build -w @luogu-saver-next/backend` which failed due to missing workspace dependency types after the install failure, so a full build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c36c41df083228a2d4d21b16943e8)