### PR TITLE
perf(frontend): skip redundant TOC/API processing for pre-rendered content and remove useless auto-render

### DIFF
--- a/packages/frontend/src/components/MarkdownViewer.vue
+++ b/packages/frontend/src/components/MarkdownViewer.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, nextTick, watch } from 'vue';
 import 'katex/dist/katex.min.css';
-import renderMathInElement from 'katex/contrib/auto-render';
 import '@/styles/markdown.css';
 import { renderMarkdown } from '@/api/markdown.ts';
 
@@ -36,20 +35,6 @@ const CHECK_SVG = `
   <polyline points="20 6 9 17 4 12"></polyline>
 </svg>
 `;
-
-const renderMath = () => {
-    if (contentRef.value) {
-        renderMathInElement(contentRef.value, {
-            delimiters: [
-                { left: '$$', right: '$$', display: true },
-                { left: '$', right: '$', display: false },
-                { left: '\\(', right: '\\)', display: false },
-                { left: '\\[', right: '\\]', display: true }
-            ],
-            throwOnError: false
-        });
-    }
-};
 
 const toggleMarkdownBlock = (event: Event) => {
     const title = event.currentTarget as HTMLElement;
@@ -140,9 +125,6 @@ const processContent = async () => {
     }
 
     await nextTick();
-    if (!props.preRendered) {
-        renderMath();
-    }
     initMarkdownBlocks();
     addCopyButtons();
     emit('rendered', renderedContent.value);

--- a/packages/frontend/src/components/MarkdownViewer.vue
+++ b/packages/frontend/src/components/MarkdownViewer.vue
@@ -140,7 +140,9 @@ const processContent = async () => {
     }
 
     await nextTick();
-    renderMath();
+    if (!props.preRendered) {
+        renderMath();
+    }
     initMarkdownBlocks();
     addCopyButtons();
     emit('rendered', renderedContent.value);

--- a/packages/frontend/src/views/article/ArticleDetailView.vue
+++ b/packages/frontend/src/views/article/ArticleDetailView.vue
@@ -231,9 +231,7 @@ const loadData = async () => {
         document.title = `${article.value.title} - 洛谷保存站`;
 
         if (article.value?.renderedContent) {
-            const result = generateTocAndProcessHtml(article.value.renderedContent);
-            displayContent.value = result.html;
-            tocItems.value = result.toc;
+            displayContent.value = article.value.renderedContent;
         }
 
         await Promise.all([loadRelevant(), loadHistory()]);


### PR DESCRIPTION
避免前端重复调用渲染。
因为当前所有 LaTeX 均在后端渲染完成，所以去掉了 auto-render