### PR TITLE
fix: article title resets on update button click

### DIFF
--- a/packages/frontend/src/routers/index.ts
+++ b/packages/frontend/src/routers/index.ts
@@ -51,8 +51,10 @@ router.beforeEach(async to => {
 
 const DEFAULT_TITLE = '洛谷保存站';
 
-router.afterEach(to => {
-    document.title = to.meta.title ? `${to.meta.title} - ${DEFAULT_TITLE}` : DEFAULT_TITLE;
+router.afterEach((to, from) => {
+    if (to.path !== from.path) {
+        document.title = to.meta.title ? `${to.meta.title} - ${DEFAULT_TITLE}` : DEFAULT_TITLE;
+    }
 });
 
 export default router;

--- a/packages/frontend/src/views/article/ArticleDetailView.vue
+++ b/packages/frontend/src/views/article/ArticleDetailView.vue
@@ -282,6 +282,9 @@ const handleUpdate = async () => {
     try {
         selectedVersion.value = null;
         router.replace({ query: {} });
+        if (article.value?.title) {
+            document.title = `${article.value.title} - 洛谷保存站`;
+        }
         await submitSaveArticle();
         message.success('更新请求已提交');
     } catch (err: any) {


### PR DESCRIPTION
修复 #13 的 “文章界面点击更新标题会变成「文章 - 洛谷保存站」而不是「<标题> - 洛谷保存站」”