### PR TITLE
[codex] Add Umami analytics tracking

### DIFF
--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -5,6 +5,11 @@
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>洛谷保存站</title>
+        <script
+            defer
+            src="https://analytics.lailai.one/script.js"
+            data-website-id="02048514-63a7-4550-91e7-263db4baaa62"
+        ></script>
     </head>
 
     <body>


### PR DESCRIPTION
## 背景

洛谷保存站目前只有 Cloudflare Web Analytics，尚未加载用户提供的自托管 Umami tracker，因此对应的 Umami 网站记录无法接收保存站访问事件。

## 修改

- 在前端 HTML 模板的 `<head>` 中加载 `https://analytics.lailai.one/script.js`；
- 使用 website ID `02048514-63a7-4550-91e7-263db4baaa62`；
- 保留现有 Cloudflare Web Analytics 配置不变。

脚本使用 `defer` 加载，不阻塞 HTML 解析。生产构建会将该标签原样写入最终 `dist/index.html`。

## 验证

- `npx prettier --check packages/frontend/index.html`
- `npm run build -w @luogu-saver/frontend`
- `npm test -w @luogu-saver/frontend`：3 个测试文件、5 个测试全部通过
- 检查构建产物包含正确的 tracker URL 和 website ID
- 请求 `https://analytics.lailai.one/script.js` 返回 HTTP 200，内容类型为 JavaScript
