### PR TITLE
支持全局宏定义

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2945,9 +2945,9 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3689,9 +3689,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5331,9 +5331,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "funding": [
                 {
                     "type": "github",
@@ -6304,9 +6304,9 @@
             }
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+            "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -6509,9 +6509,9 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "funding": [
                 {
                     "type": "github",
@@ -8357,9 +8357,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",
@@ -8967,9 +8967,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.20",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-            "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+            "version": "8.5.26",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+            "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -8986,7 +8986,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.16",
+                "nanoid": "^3.3.17",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -10561,9 +10561,9 @@
             }
         },
         "node_modules/tar": {
-            "version": "7.5.20",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-            "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+            "version": "7.5.22",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+            "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "@isaacs/fs-minipass": "^4.0.0",
@@ -11100,9 +11100,9 @@
             }
         },
         "node_modules/typeorm/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"

--- a/packages/markdown-renderer/src/index.ts
+++ b/packages/markdown-renderer/src/index.ts
@@ -314,6 +314,7 @@ function parseMarkdown(processor: any, src: string) {
 
     while (true) {
         const file = new VFile(protectedSrc);
+        file.data.macros = {};
         const tree = processor.parse(file);
         const isTextOffset = createTextOffsetLookup(protectedSrc);
         const fences = findUnclosedMathFences(protectedSrc, tree, isTextOffset);
@@ -330,9 +331,10 @@ function parseMarkdown(processor: any, src: string) {
 }
 
 function rehypeSafeKatex(options?: Parameters<typeof rehypeKatex>[0]) {
-    const transform = rehypeKatex(options);
-
     return (tree: Root, file: VFile) => {
+        const macros = file.data.macros || {};
+        const transform = rehypeKatex({ ...options, macros });
+
         visit(tree, 'element', node => {
             node.properties ||= {};
         });

--- a/packages/markdown-renderer/test/math-fences.test.mjs
+++ b/packages/markdown-renderer/test/math-fences.test.mjs
@@ -165,3 +165,33 @@ test('preserves table merge processing with the normalized source file', async (
     assert.match(html, /rowspan="2"/);
     assert.doesNotMatch(html, /<td>\^<\/td>/);
 });
+
+// 接下来是测试关于宏定义
+
+test('isolates global macros between render calls', async () => {
+    const html1 = await renderMarkdown('$\\gdef\\foo{bar}$');
+    const html2 = await renderMarkdown('$\\foo$');
+    assert.doesNotMatch(html1, /katex-error/);
+    assert.match(html2, /color:#cc0000[^>]*>\\foo</);
+});
+
+test('shares global macros across math blocks in the same render and redefines', async () => {
+    const html = await renderMarkdown([
+        // Inline → Inline
+        '$\\gdef\\a{\\alpha} \\a$', '$\\a$', '',
+        // Display → Display
+        '$$\\gdef\\b{\\beta} \\b$$', '$$\\b$$', '',
+        // Inline → Display
+        '$\\gdef\\c{\\gamma} \\c$', '$$\\c$$', '',
+        // Display → Inline
+        '$$\\gdef\\d{\\Delta} \\gdef\\d{\\delta} \\d$$', '$\\d$',
+    ].join('\n'));
+
+    // 确保重定义宏用新的
+    assert.match(html, /δ/);
+    assert.doesNotMatch(html, /Δ/);
+    // 所有四种方向都不应该有 KaTeX 报错
+    assert.doesNotMatch(html, /katex-error/);
+    // 确认没有未定义的宏被红色高亮
+    assert.doesNotMatch(html, /color:#cc0000/);
+});

--- a/packages/markdown-renderer/test/math-fences.test.mjs
+++ b/packages/markdown-renderer/test/math-fences.test.mjs
@@ -176,16 +176,25 @@ test('isolates global macros between render calls', async () => {
 });
 
 test('shares global macros across math blocks in the same render and redefines', async () => {
-    const html = await renderMarkdown([
-        // Inline → Inline
-        '$\\gdef\\a{\\alpha} \\a$', '$\\a$', '',
-        // Display → Display
-        '$$\\gdef\\b{\\beta} \\b$$', '$$\\b$$', '',
-        // Inline → Display
-        '$\\gdef\\c{\\gamma} \\c$', '$$\\c$$', '',
-        // Display → Inline
-        '$$\\gdef\\d{\\Delta} \\gdef\\d{\\delta} \\d$$', '$\\d$',
-    ].join('\n'));
+    const html = await renderMarkdown(
+        [
+            // Inline → Inline
+            '$\\gdef\\a{\\alpha} \\a$',
+            '$\\a$',
+            '',
+            // Display → Display
+            '$$\\gdef\\b{\\beta} \\b$$',
+            '$$\\b$$',
+            '',
+            // Inline → Display
+            '$\\gdef\\c{\\gamma} \\c$',
+            '$$\\c$$',
+            '',
+            // Display → Inline
+            '$$\\gdef\\d{\\Delta} \\gdef\\d{\\delta} \\d$$',
+            '$\\d$'
+        ].join('\n')
+    );
 
     // 确保重定义宏用新的
     assert.match(html, /δ/);

--- a/spec/markdown-system.spec.md
+++ b/spec/markdown-system.spec.md
@@ -92,7 +92,7 @@ If a supported directive title contains Markdown math syntax, the title SHALL re
 
 For input `::::success[$$\\displaystyle\\sum_{i = 1}^n i$$]`, the rendered title SHALL contain KaTeX HTML and SHALL NOT render the raw TeX text as plain text.
 
-## 6.1 Unclosed Display Math Fences
+### 6.1 Unclosed Display Math Fences
 
 A standalone display math fence is unclosed if `remark-math` parses a line containing only an opening sequence of two or more dollar signs and optional whitespace as a `math` node, and the node does not end with a valid closing display math fence.
 
@@ -109,7 +109,7 @@ Given input lines `normal text`, an empty line, `$$`, `inline math: $$ a = b $$`
 
 A display math fence with a valid closing fence SHALL retain normal display-math behavior. Dollar-sign sequences inside indented code or fenced code blocks SHALL retain normal code behavior.
 
-## 6.2 Multiline Display Math With Attached Content
+### 6.2 Multiline Display Math With Attached Content
 
 A display math region in normal Markdown text is an attached-content multiline region if all of these conditions hold:
 
@@ -140,7 +140,7 @@ $$\begin{aligned}a&=\begin{vmatrix}
 
 Dollar-sign sequences inside indented code blocks or fenced code blocks SHALL retain normal code behavior.
 
-## 6.3 Single-Line Display Math
+### 6.3 Single-Line Display Math
 
 A line in normal Markdown text is a single-line display math region if all of these conditions hold:
 
@@ -163,13 +163,11 @@ The frontend SHALL NOT center a paragraph solely because its only element child 
 
 Dollar-sign sequences inside indented code blocks or fenced code blocks SHALL retain normal code behavior.
 
-## 6.4 GFM Task Lists
+### 6.4 Global Macros
 
-For GFM task list input `- [ ] item` or `- [x] item`, the renderer SHALL preserve checkbox inputs in the output HTML.
+A macro defined via `\gdef\<name>{<body>}` in any math block SHALL be available to all subsequent math blocks within the same document.
 
-The checked state SHALL match the Markdown marker.
-
-The checkbox inputs SHALL be disabled.
+The `macros` object SHALL be created once per rendering pass and SHALL NOT be shared across separate requests.
 
 ## 7. Unsupported Directives
 
@@ -288,3 +286,11 @@ except for the Bilibili conversion defined in Section 12.
 The endpoint SHALL render `markdown` with the shared renderer and return `{ html }`.
 
 If `markdown` is absent, the endpoint SHALL render the empty string.
+
+## 14. GFM Task Lists
+
+For GFM task list input `- [ ] item` or `- [x] item`, the renderer SHALL preserve checkbox inputs in the output HTML.
+
+The checked state SHALL match the Markdown marker.
+
+The checkbox inputs SHALL be disabled.


### PR DESCRIPTION
fix #70.

通过增加 `macros` 以支持全局宏定义，并加上几个相关的测试。

修改文档 spec\markdown-system.spec.md 时发现  6. Math Rendering Warnings 结构混乱，将 GFM Task Lists 移出为 14 章（与 math rending 无关），并添加关于全局宏定义功能的说明。