### PR TITLE
Support Global Macros

### DIFF
--- a/packages/markdown-renderer/src/index.ts
+++ b/packages/markdown-renderer/src/index.ts
@@ -314,6 +314,7 @@ function parseMarkdown(processor: any, src: string) {
 
     while (true) {
         const file = new VFile(protectedSrc);
+        file.data.macros = {};
         const tree = processor.parse(file);
         const isTextOffset = createTextOffsetLookup(protectedSrc);
         const fences = findUnclosedMathFences(protectedSrc, tree, isTextOffset);
@@ -330,9 +331,10 @@ function parseMarkdown(processor: any, src: string) {
 }
 
 function rehypeSafeKatex(options?: Parameters<typeof rehypeKatex>[0]) {
-    const transform = rehypeKatex(options);
-
     return (tree: Root, file: VFile) => {
+        const macros = file.data.macros || {};
+        const transform = rehypeKatex({ ...options, macros });
+
         visit(tree, 'element', node => {
             node.properties ||= {};
         });

--- a/packages/markdown-renderer/test/math-fences.test.mjs
+++ b/packages/markdown-renderer/test/math-fences.test.mjs
@@ -165,3 +165,42 @@ test('preserves table merge processing with the normalized source file', async (
     assert.match(html, /rowspan="2"/);
     assert.doesNotMatch(html, /<td>\^<\/td>/);
 });
+
+// 接下来是测试关于宏定义
+
+test('isolates global macros between render calls', async () => {
+    const html1 = await renderMarkdown('$\\gdef\\foo{bar}$');
+    const html2 = await renderMarkdown('$\\foo$');
+    assert.doesNotMatch(html1, /katex-error/);
+    assert.match(html2, /color:#cc0000[^>]*>\\foo</);
+});
+
+test('shares global macros across math blocks in the same render and redefines', async () => {
+    const html = await renderMarkdown(
+        [
+            // Inline → Inline
+            '$\\gdef\\a{\\alpha} \\a$',
+            '$\\a$',
+            '',
+            // Display → Display
+            '$$\\gdef\\b{\\beta} \\b$$',
+            '$$\\b$$',
+            '',
+            // Inline → Display
+            '$\\gdef\\c{\\gamma} \\c$',
+            '$$\\c$$',
+            '',
+            // Display → Inline
+            '$$\\gdef\\d{\\Delta} \\gdef\\d{\\delta} \\d$$',
+            '$\\d$'
+        ].join('\n')
+    );
+
+    // 确保重定义宏用新的
+    assert.match(html, /δ/);
+    assert.doesNotMatch(html, /Δ/);
+    // 所有四种方向都不应该有 KaTeX 报错
+    assert.doesNotMatch(html, /katex-error/);
+    // 确认没有未定义的宏被红色高亮
+    assert.doesNotMatch(html, /color:#cc0000/);
+});

--- a/spec/markdown-system.spec.md
+++ b/spec/markdown-system.spec.md
@@ -92,7 +92,7 @@ If a supported directive title contains Markdown math syntax, the title SHALL re
 
 For input `::::success[$$\\displaystyle\\sum_{i = 1}^n i$$]`, the rendered title SHALL contain KaTeX HTML and SHALL NOT render the raw TeX text as plain text.
 
-## 6.1 Unclosed Display Math Fences
+### 6.1 Unclosed Display Math Fences
 
 A standalone display math fence is unclosed if `remark-math` parses a line containing only an opening sequence of two or more dollar signs and optional whitespace as a `math` node, and the node does not end with a valid closing display math fence.
 
@@ -109,7 +109,7 @@ Given input lines `normal text`, an empty line, `$$`, `inline math: $$ a = b $$`
 
 A display math fence with a valid closing fence SHALL retain normal display-math behavior. Dollar-sign sequences inside indented code or fenced code blocks SHALL retain normal code behavior.
 
-## 6.2 Multiline Display Math With Attached Content
+### 6.2 Multiline Display Math With Attached Content
 
 A display math region in normal Markdown text is an attached-content multiline region if all of these conditions hold:
 
@@ -140,7 +140,7 @@ $$\begin{aligned}a&=\begin{vmatrix}
 
 Dollar-sign sequences inside indented code blocks or fenced code blocks SHALL retain normal code behavior.
 
-## 6.3 Single-Line Display Math
+### 6.3 Single-Line Display Math
 
 A line in normal Markdown text is a single-line display math region if all of these conditions hold:
 
@@ -163,13 +163,11 @@ The frontend SHALL NOT center a paragraph solely because its only element child 
 
 Dollar-sign sequences inside indented code blocks or fenced code blocks SHALL retain normal code behavior.
 
-## 6.4 GFM Task Lists
+### 6.4 Global Macros
 
-For GFM task list input `- [ ] item` or `- [x] item`, the renderer SHALL preserve checkbox inputs in the output HTML.
+A macro defined via `\gdef\<name>{<body>}` in any math block SHALL be available to all subsequent math blocks within the same document.
 
-The checked state SHALL match the Markdown marker.
-
-The checkbox inputs SHALL be disabled.
+The `macros` object SHALL be created once per rendering pass and SHALL NOT be shared across separate requests.
 
 ## 7. Unsupported Directives
 
@@ -288,3 +286,11 @@ except for the Bilibili conversion defined in Section 12.
 The endpoint SHALL render `markdown` with the shared renderer and return `{ html }`.
 
 If `markdown` is absent, the endpoint SHALL render the empty string.
+
+## 14. GFM Task Lists
+
+For GFM task list input `- [ ] item` or `- [x] item`, the renderer SHALL preserve checkbox inputs in the output HTML.
+
+The checked state SHALL match the Markdown marker.
+
+The checkbox inputs SHALL be disabled.


### PR DESCRIPTION
fix #70 .

通过增加 `macros` 以支持全局宏定义，并加上几个相关的测试。

修改文档 `spec\markdown-system.spec.md` 时发现 6. Math Rendering Warnings 结构混乱，将 GFM Task Lists 移出为 14 章（与 math rending 无关），并添加关于全局宏定义功能的说明。