### PR TITLE
feat(article,paste): persist the Luogu publish time

### DIFF
--- a/packages/backend/src/entities/article.ts
+++ b/packages/backend/src/entities/article.ts
@@ -58,6 +58,12 @@ export class Article extends BaseEntity {
     @Column({ type: 'json' })
     tags: string[];
 
+    // Luogu's own publish time, unix seconds. Distinct from createdAt, which records when this
+    // system first archived the row; for a late archive the two differ without bound. Null means
+    // no non-skipped save has written it yet, and is never substituted with 0 or createdAt.
+    @Column({ name: 'publish_time', type: 'int', unsigned: true, nullable: true })
+    publishTime?: number | null;
+
     @CreateDateColumn({ name: 'created_at' })
     @Type(() => Date)
     createdAt: Date;

--- a/packages/backend/src/entities/paste.ts
+++ b/packages/backend/src/entities/paste.ts
@@ -31,6 +31,12 @@ export class Paste extends BaseEntity {
     @Column({ type: 'tinyint', default: 0 })
     deleted: boolean;
 
+    // Luogu's own publish time, unix seconds. Distinct from createdAt, which records when this
+    // system first archived the row; for a late archive the two differ without bound. Null means
+    // no non-skipped save has written it yet, and is never substituted with 0 or createdAt.
+    @Column({ name: 'publish_time', type: 'int', unsigned: true, nullable: true })
+    publishTime?: number | null;
+
     @CreateDateColumn({ name: 'created_at' })
     @Type(() => Date)
     createdAt: Date;

--- a/packages/backend/src/services/article.service.ts
+++ b/packages/backend/src/services/article.service.ts
@@ -336,7 +336,8 @@ export class ArticleService {
                         category: data.category as ArticleCategory,
                         solutionForPid: data.solutionFor?.pid,
                         upvote: data.upvote,
-                        favorCount: data.favorCount
+                        favorCount: data.favorCount,
+                        publishTime: data.time
                     },
                     defaults: {
                         deleted: false,

--- a/packages/backend/src/services/paste.service.ts
+++ b/packages/backend/src/services/paste.service.ts
@@ -51,7 +51,8 @@ export class PasteService {
                     content: data.data,
                     forceUpdate,
                     incomingData: {
-                        authorId: data.user.uid
+                        authorId: data.user.uid,
+                        publishTime: data.time
                     },
                     defaults: {
                         deleted: false

--- a/packages/frontend/src/types/article.d.ts
+++ b/packages/frontend/src/types/article.d.ts
@@ -16,6 +16,7 @@ export interface Article {
     updatedAt: string;
     deleteReason?: string | null;
     contentHash?: string;
+    publishTime?: number | null;
     viewCount: number;
     author?: User;
     renderedContent?: string;

--- a/packages/frontend/src/types/paste.d.ts
+++ b/packages/frontend/src/types/paste.d.ts
@@ -5,6 +5,7 @@ export interface Paste {
     content: string;
     authorId?: number;
     deleted: boolean;
+    publishTime?: number | null;
     createdAt: string;
     updatedAt: string;
     deleteReason: string;

--- a/spec/article-system.spec.md
+++ b/spec/article-system.spec.md
@@ -23,8 +23,9 @@ Table name: `article`
 | `priority`            | INT          | DEFAULT 0               | Display priority                   |
 | `deleted`             | TINYINT      | DEFAULT 0               | Soft delete flag                   |
 | `tags`                | JSON         | NOT NULL                | Array of tag strings               |
-| `created_at`          | DATETIME     | NOT NULL                | Record creation timestamp          |
-| `updated_at`          | DATETIME     | NOT NULL                | Record update timestamp            |
+| `publish_time`        | INT UNSIGNED | NULLABLE                | Luogu publish time in Unix seconds |
+| `created_at`          | DATETIME     | NOT NULL                | Local persistence time             |
+| `updated_at`          | DATETIME     | NOT NULL                | Local update time                  |
 | `delete_reason`       | VARCHAR      | NULLABLE                | Reason for deletion                |
 | `content_hash`        | VARCHAR      | NULLABLE                | SHA-256 hash of content            |
 | `view_count`          | INT          | DEFAULT 0               | View count                         |
@@ -232,12 +233,31 @@ Article candidate methods used by recommendation SHALL select article IDs only. 
 select `content`, `summary`, or author relations. Full article rows SHALL be loaded only for the
 final selected recommendation IDs.
 
+### 7.1 Publish Time Persistence
+
+`saveLuoguArticle(data, forceUpdate)` SHALL write `data.time` into `publish_time` on every path that
+writes the row, that is on the insert of step 4 and on the update of step 7.
+
+Because step 3 returns without writing, an article whose stored `contentHash` and `title` both match
+the incoming values retains its existing `publish_time`. For a row inserted before this column
+existed, `publish_time` therefore remains `NULL` until the next save that is not skipped. Callers
+that require the value for such a row SHALL request a save with `forceUpdate = true`.
+
+`publish_time` SHALL NOT be written from any source other than the `time` field of the Luogu article
+payload.
+
 ## 8. Invariants
 
 1. `version` numbers are strictly monotonically increasing per article.
 2. Non-deleted articles (`deleted = false`) are returned in queries unless explicitly filtered.
 3. All article queries include the `author` relation.
 4. Content truncation preserves UTF-8 character boundaries.
+5. `publish_time` and `created_at` denote different instants and SHALL NOT be substituted for one
+   another. `publish_time` is the instant Luogu reports for the article itself; `created_at` is the
+   instant this system first persisted the row. For an article archived long after publication the
+   two differ without bound.
+6. `publish_time` is `NULL` if and only if no successful save has written it for that article. It is
+   never `0` and never derived from `created_at`.
 
 ## 9. Summary Rebuild Workflow
 

--- a/spec/paste-system.spec.md
+++ b/spec/paste-system.spec.md
@@ -10,16 +10,17 @@ The paste system manages code/text pastes archived from Luogu. It provides stora
 
 Table name: `paste`
 
-| Column          | Type         | Constraints             | Description               |
-| --------------- | ------------ | ----------------------- | ------------------------- |
-| `id`            | VARCHAR(8)   | PRIMARY KEY             | Paste ID (from Luogu)     |
-| `content`       | MEDIUMTEXT   | NOT NULL                | Paste content             |
-| `author_id`     | INT UNSIGNED | NOT NULL, FK -> user.id | Author user ID            |
-| `deleted`       | TINYINT      | DEFAULT 0               | Soft delete flag          |
-| `created_at`    | DATETIME     | NOT NULL                | Record creation timestamp |
-| `updated_at`    | DATETIME     | NOT NULL                | Record update timestamp   |
-| `delete_reason` | VARCHAR      | DEFAULT '管理员删除'    | Reason for deletion       |
-| `content_hash`  | VARCHAR      | NULLABLE                | SHA-256 hash of content   |
+| Column          | Type         | Constraints             | Description                        |
+| --------------- | ------------ | ----------------------- | ---------------------------------- |
+| `id`            | VARCHAR(8)   | PRIMARY KEY             | Paste ID (from Luogu)              |
+| `content`       | MEDIUMTEXT   | NOT NULL                | Paste content                      |
+| `author_id`     | INT UNSIGNED | NOT NULL, FK -> user.id | Author user ID                     |
+| `deleted`       | TINYINT      | DEFAULT 0               | Soft delete flag                   |
+| `publish_time`  | INT UNSIGNED | NULLABLE                | Luogu publish time in Unix seconds |
+| `created_at`    | DATETIME     | NOT NULL                | Local persistence time             |
+| `updated_at`    | DATETIME     | NOT NULL                | Local update time                  |
+| `delete_reason` | VARCHAR      | DEFAULT '管理员删除'    | Reason for deletion                |
+| `content_hash`  | VARCHAR      | NULLABLE                | SHA-256 hash of content            |
 
 ### 2.2 Indexes
 
@@ -154,7 +155,7 @@ When a cached read method receives a manager argument, it SHALL bypass Redis cac
 
 1. Compute `SHA-256(data.data)`.
 2. If a paste with `id=data.id` exists, `forceUpdate=false`, and `content_hash` equals the computed hash, return `{ skipped: true, content: "" }` without updating the database.
-3. Otherwise upsert a paste row with `id=data.id`, `content=data.data`, `author_id=data.user.uid`, `content_hash` equal to the computed hash, and `deleted=false` for newly inserted rows.
+3. Otherwise upsert a paste row with `id=data.id`, `content=data.data`, `author_id=data.user.uid`, `publish_time=data.time`, `content_hash` equal to the computed hash, and `deleted=false` for newly inserted rows.
 4. Return `{ skipped: false, content }` where `content` equals the saved paste content.
 5. A missing paste row SHALL be inserted before any pessimistic row lock is requested.
 6. MariaDB deadlock and lock-wait timeout errors SHALL retry the complete paste transaction at most three times.
@@ -201,6 +202,13 @@ The default value for `delete_reason` is `'管理员删除'` (Administrator dele
 2. Non-deleted pastes (`deleted = false`) are counted in `getPasteCount()`.
 3. Deleted pastes remain queryable. Their detail endpoint returns 200 for an authenticated
    administrator and 403 for every other requester.
+4. `publish_time` and `created_at` denote different instants and SHALL NOT be substituted for one
+   another. `publish_time` is the instant Luogu reports for the paste itself; `created_at` is the
+   instant this system first persisted the row.
+5. `publish_time` is `NULL` if and only if no successful save has written it for that paste. It is
+   never `0` and never derived from `created_at`. Step 2 of `saveLuoguPaste` returns without
+   writing, so a row inserted before this column existed retains `NULL` until the next save that is
+   not skipped; callers that need the value SHALL request `forceUpdate = true`.
 
 ## 8. File Locations
 


### PR DESCRIPTION
Closes #76.

The save pipelines already receive Luogu's own publish time and drop it, so the only timestamps stored are `created_at` and `updated_at`, both of which describe when this system touched the row rather than when the author published. This adds a nullable `publish_time` column to `article` and `paste` and writes `data.time` into it.

## Changes

- `entities/article.ts`, `entities/paste.ts` — add `publish_time`.
- `services/article.service.ts`, `services/paste.service.ts` — add `publishTime: data.time` to `incomingData`.
- `types/article.d.ts`, `types/paste.d.ts` (frontend) — add the optional field.
- `spec/article-system.spec.md`, `spec/paste-system.spec.md` — schema rows, save semantics, invariants.

## Notes on the choices

**INT UNSIGNED, not BIGINT.** There are two existing conventions for storing a Luogu timestamp: `article_comment.comment_time` uses BIGINT, `judgement_record.time` uses INT UNSIGNED. I followed the latter, because BIGINT currently reaches API consumers as a string — `GET /article/comments/:id` returns `"time": "1769219799"` today, while Luogu itself sends a number. INT UNSIGNED holds Unix seconds through 2106 and keeps the value a JSON number. `spec/judgement-system.spec.md` also already describes exactly the distinction being added here, calling `time` "Luogu event time in Unix seconds" next to a `created_at` that is "Local persistence time".

**Nullable, no default.** The real publish time of an already-archived row is unknown, and deriving it from `created_at` or defaulting it to `0` would silently assert something false. `NULL` means "no successful save has written this yet".

**Backfill.** `saveHashedContent` returns early when the content hash and title both match, so rows inserted before this change keep `NULL` until the next save that is not skipped. A `forceUpdate` refresh fills them in. Both specs state this rather than leaving it implicit.

**No new migration.** The data source runs with `synchronize: true`, and the column is nullable, so the ALTER is safe on existing tables.

## Verification

- `npx eslint .`, `npx prettier --check .` — clean.
- `npx vue-tsc -p packages/frontend/tsconfig.app.json --noEmit` — clean.
- `npm test` — backend 5, frontend 5, markdown-renderer 17, all passing.
- `npm run build` for `@luogu-saver/backend` and `@luogu-saver/frontend` — both succeed.

I did not exercise the write against a live database. The mapping is guarded by the type checker rather than by a test, and I confirmed that guard is load-bearing: renaming the entity property, and changing its declared type from `number` to `string`, each make `tsc` fail, while the baseline is clean. A unit test at the `saveHashedContent` level would need vitest to resolve the `@/` alias, which is not configured today; I left the test setup alone rather than widen this change.
