### PR TITLE
fix(article,paste): fill the publish time that a skipped save leaves behind

### DIFF
--- a/packages/backend/src/services/article.service.ts
+++ b/packages/backend/src/services/article.service.ts
@@ -11,6 +11,7 @@ import {
     saveServiceEntity
 } from '@/services/helpers/repository.helper';
 import { saveHashedContent } from '@/services/helpers/hashed-content.helper';
+import { backfillPublishTime, normalizePublishTime } from '@/services/helpers/publish-time.helper';
 import type { Article as LuoguArticle } from '@/types/luogu-api';
 import { retryOnTransactionConflict } from '@/utils/db-errors';
 
@@ -322,6 +323,7 @@ export class ArticleService {
         data: LuoguArticle,
         forceUpdate: boolean = false
     ): Promise<{ skipped: boolean; content: string }> {
+        const publishTime = normalizePublishTime(data.time);
         return retryOnTransactionConflict(() =>
             Article.transaction(async manager => {
                 const saveResult = await saveHashedContent<Article>({
@@ -337,7 +339,9 @@ export class ArticleService {
                         solutionForPid: data.solutionFor?.pid,
                         upvote: data.upvote,
                         favorCount: data.favorCount,
-                        publishTime: data.time
+                        // Omitted rather than written as null: an unusable `time` must not
+                        // erase a publish time an earlier payload already delivered.
+                        ...(publishTime === null ? {} : { publishTime })
                     },
                     defaults: {
                         deleted: false,
@@ -351,6 +355,7 @@ export class ArticleService {
                 });
 
                 if (saveResult.skipped || !saveResult.entity) {
+                    await backfillPublishTime(manager, Article, data.lid, data.time);
                     return { skipped: true, content: '' };
                 }
 

--- a/packages/backend/src/services/helpers/publish-time.helper.ts
+++ b/packages/backend/src/services/helpers/publish-time.helper.ts
@@ -1,0 +1,59 @@
+import { EntityManager, EntityTarget, IsNull, ObjectLiteral } from 'typeorm';
+
+const PUBLISH_TIME_MAX = 4_294_967_295;
+
+/**
+ * Narrows a Luogu `time` field to a value that may be stored in a `publish_time` column.
+ *
+ * @param value The `time` field of a Luogu article or paste payload.
+ * @return `value` when it is an integer in `[1, 4294967295]`, the range of the `INT UNSIGNED`
+ *     column; `null` for every other input, including `0`, which Luogu uses for no value.
+ */
+export function normalizePublishTime(value: unknown): number | null {
+    return typeof value === 'number' &&
+        Number.isInteger(value) &&
+        value >= 1 &&
+        value <= PUBLISH_TIME_MAX
+        ? value
+        : null;
+}
+
+/**
+ * Stores `time` as the publish time of one archived document, but only while the stored value is
+ * still `NULL`.
+ *
+ * A save whose content hash is unchanged returns without writing, so rows archived before
+ * `publish_time` existed would keep `NULL` for as long as their content never changes. This fills
+ * them from the payload that save already fetched.
+ *
+ * @param manager The manager of the transaction that owns the row.
+ * @param entity An archived document entity carrying an `id` primary key and a nullable
+ *     `publishTime` property. TypeORM's `EntityTarget` accepts any `Function`, so this requirement
+ *     cannot be expressed as a type constraint.
+ * @param id Primary key of the row.
+ * @param time The `time` field of the Luogu payload; an unusable value writes nothing.
+ */
+export async function backfillPublishTime(
+    manager: EntityManager,
+    entity: EntityTarget<ObjectLiteral>,
+    id: string,
+    time: unknown
+): Promise<void> {
+    const publishTime = normalizePublishTime(time);
+    if (publishTime === null) return;
+
+    const values: ObjectLiteral = { publishTime };
+    const updateDateColumn = manager.connection.getMetadata(entity).updateDateColumn;
+    if (updateDateColumn) {
+        // Assigning the update date to itself suppresses the `= CURRENT_TIMESTAMP` that
+        // UpdateQueryBuilder appends otherwise: giving a row the publish time it always had is not
+        // an update of the archived document, and must not reorder listings sorted by that column.
+        const column = manager.connection.driver.escape(updateDateColumn.databaseName);
+        values[updateDateColumn.propertyName] = () => column;
+    }
+
+    // The `IS NULL` predicate is what makes this safe to run after every skipped save: it cannot
+    // overwrite a stored publish time, so no read of the current value is needed and a concurrent
+    // writer cannot lose one.
+    await manager.update(entity, { id, publishTime: IsNull() }, values);
+}

--- a/packages/backend/src/services/paste.service.ts
+++ b/packages/backend/src/services/paste.service.ts
@@ -8,6 +8,7 @@ import {
     saveServiceEntity
 } from '@/services/helpers/repository.helper';
 import { saveHashedContent } from '@/services/helpers/hashed-content.helper';
+import { backfillPublishTime, normalizePublishTime } from '@/services/helpers/publish-time.helper';
 import type { Paste as LuoguPaste } from '@/types/luogu-api';
 import { retryOnTransactionConflict } from '@/utils/db-errors';
 
@@ -42,6 +43,7 @@ export class PasteService {
         data: LuoguPaste,
         forceUpdate: boolean = false
     ): Promise<{ skipped: boolean; content: string }> {
+        const publishTime = normalizePublishTime(data.time);
         return retryOnTransactionConflict(() =>
             Paste.transaction(async manager => {
                 const saveResult = await saveHashedContent<Paste>({
@@ -52,7 +54,9 @@ export class PasteService {
                     forceUpdate,
                     incomingData: {
                         authorId: data.user.uid,
-                        publishTime: data.time
+                        // Omitted rather than written as null: an unusable `time` must not
+                        // erase a publish time an earlier payload already delivered.
+                        ...(publishTime === null ? {} : { publishTime })
                     },
                     defaults: {
                         deleted: false
@@ -60,6 +64,7 @@ export class PasteService {
                 });
 
                 if (saveResult.skipped || !saveResult.entity) {
+                    await backfillPublishTime(manager, Paste, data.id, data.time);
                     return { skipped: true, content: '' };
                 }
 

--- a/packages/backend/test/publish-time.test.ts
+++ b/packages/backend/test/publish-time.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { DataSource, EntitySchema } from 'typeorm';
+import {
+    backfillPublishTime,
+    normalizePublishTime
+} from '../src/services/helpers/publish-time.helper';
+
+type ArchivedRow = {
+    id: string;
+    publishTime: number | null;
+    updatedAt: Date;
+};
+
+// The helper addresses columns through entity metadata rather than a concrete class, so the
+// archived-document shape is declared here instead of importing `Article` or `Paste`: what is under
+// test is the statement the helper emits against a real engine, not either entity's own mapping.
+const ArchivedDocument = new EntitySchema<ArchivedRow>({
+    name: 'archived_document',
+    tableName: 'archived_document',
+    columns: {
+        id: { type: String, primary: true },
+        publishTime: { name: 'publish_time', type: Number, nullable: true },
+        updatedAt: { name: 'updated_at', type: Date, updateDate: true }
+    }
+});
+
+const LAST_UPDATE = new Date('2020-01-01T00:00:00.000Z');
+
+let dataSource: DataSource;
+
+async function seed(id: string, publishTime: number | null): Promise<void> {
+    const repository = dataSource.getRepository(ArchivedDocument);
+    await repository.insert({ id, publishTime, updatedAt: LAST_UPDATE });
+    // The insert lets TypeORM stamp the update date, so pin it to a known past instant. A helper
+    // that touches the column moves it to now, which no clock resolution can hide.
+    await repository.query('UPDATE archived_document SET updated_at = ? WHERE id = ?', [
+        LAST_UPDATE.toISOString(),
+        id
+    ]);
+}
+
+async function read(id: string): Promise<{ publishTime: number | null; updatedAt: string }> {
+    const [row] = await dataSource
+        .getRepository(ArchivedDocument)
+        .query(
+            'SELECT publish_time AS publishTime, updated_at AS updatedAt FROM ' +
+                'archived_document WHERE id = ?',
+            [id]
+        );
+    return row;
+}
+
+beforeEach(async () => {
+    dataSource = new DataSource({
+        type: 'sqljs',
+        entities: [ArchivedDocument],
+        synchronize: true
+    });
+    await dataSource.initialize();
+});
+
+afterEach(async () => {
+    await dataSource.destroy();
+});
+
+describe('normalizePublishTime', () => {
+    it('accepts a Unix second inside the INT UNSIGNED range', () => {
+        expect(normalizePublishTime(1_759_276_800)).toBe(1_759_276_800);
+        expect(normalizePublishTime(1)).toBe(1);
+        expect(normalizePublishTime(4_294_967_295)).toBe(4_294_967_295);
+    });
+
+    it('rejects every value that would store a fabricated instant', () => {
+        for (const value of [
+            0,
+            -1,
+            1.5,
+            Number.NaN,
+            Number.POSITIVE_INFINITY,
+            4_294_967_296,
+            1_759_276_800_000,
+            null,
+            undefined,
+            '1759276800',
+            {}
+        ]) {
+            expect(normalizePublishTime(value)).toBeNull();
+        }
+    });
+});
+
+describe('backfillPublishTime', () => {
+    it('fills a row whose publish time is still NULL', async () => {
+        await seed('a', null);
+
+        await backfillPublishTime(dataSource.manager, ArchivedDocument, 'a', 1_759_276_800);
+
+        expect((await read('a')).publishTime).toBe(1_759_276_800);
+    });
+
+    it('leaves the update date untouched, because filling it is not an archive update', async () => {
+        await seed('a', null);
+
+        await backfillPublishTime(dataSource.manager, ArchivedDocument, 'a', 1_759_276_800);
+
+        expect(new Date((await read('a')).updatedAt).getTime()).toBe(LAST_UPDATE.getTime());
+    });
+
+    it('never overwrites a publish time that is already stored', async () => {
+        await seed('a', 1_000_000_000);
+
+        await backfillPublishTime(dataSource.manager, ArchivedDocument, 'a', 1_759_276_800);
+
+        expect((await read('a')).publishTime).toBe(1_000_000_000);
+    });
+
+    it('writes nothing when Luogu reports a time that cannot be trusted', async () => {
+        await seed('a', null);
+
+        await backfillPublishTime(dataSource.manager, ArchivedDocument, 'a', 0);
+        await backfillPublishTime(dataSource.manager, ArchivedDocument, 'a', undefined);
+
+        const row = await read('a');
+        expect(row.publishTime).toBeNull();
+        expect(new Date(row.updatedAt).getTime()).toBe(LAST_UPDATE.getTime());
+    });
+
+    it('is idempotent across repeated skipped saves', async () => {
+        await seed('a', null);
+
+        await backfillPublishTime(dataSource.manager, ArchivedDocument, 'a', 1_759_276_800);
+        await backfillPublishTime(dataSource.manager, ArchivedDocument, 'a', 1_759_276_801);
+
+        const row = await read('a');
+        expect(row.publishTime).toBe(1_759_276_800);
+        expect(new Date(row.updatedAt).getTime()).toBe(LAST_UPDATE.getTime());
+    });
+
+    it('touches no other row', async () => {
+        await seed('a', null);
+        await seed('b', null);
+
+        await backfillPublishTime(dataSource.manager, ArchivedDocument, 'a', 1_759_276_800);
+
+        expect((await read('b')).publishTime).toBeNull();
+    });
+});

--- a/spec/article-system.spec.md
+++ b/spec/article-system.spec.md
@@ -235,13 +235,27 @@ final selected recommendation IDs.
 
 ### 7.1 Publish Time Persistence
 
-`saveLuoguArticle(data, forceUpdate)` SHALL write `data.time` into `publish_time` on every path that
-writes the row, that is on the insert of step 4 and on the update of step 7.
+Let `t = normalizePublishTime(data.time)`, where `normalizePublishTime(v)` returns `v` if `v` is an
+integer satisfying `1 <= v <= 4294967295`, and `null` otherwise. The upper bound is the maximum of
+the `INT UNSIGNED` column; the lower bound rejects `0`, which Luogu uses for no value.
 
-Because step 3 returns without writing, an article whose stored `contentHash` and `title` both match
-the incoming values retains its existing `publish_time`. For a row inserted before this column
-existed, `publish_time` therefore remains `NULL` until the next save that is not skipped. Callers
-that require the value for such a row SHALL request a save with `forceUpdate = true`.
+`saveLuoguArticle(data, forceUpdate)` SHALL write `t` into `publish_time` on the insert of step 4 and
+on the update of step 7. If `t` is `null`, `publish_time` SHALL be absent from both write payloads,
+so that a malformed `time` neither inserts nor overwrites a value.
+
+Step 3 returns without writing, so a row whose stored `contentHash` and `title` both match the
+incoming values keeps whatever `publish_time` it already had, including `NULL` for a row inserted
+before this column existed. When step 3 skips and `t` is not `null`, `saveLuoguArticle` SHALL
+therefore execute exactly one additional statement, inside the transaction that already holds the
+pessimistic lock of step 5:
+
+```sql
+UPDATE article SET publish_time = :t WHERE id = :id AND publish_time IS NULL
+```
+
+That statement SHALL leave `updated_at` unchanged, SHALL NOT create an `article_history` version,
+and SHALL affect zero rows once `publish_time` is set. It is therefore idempotent, and repeating a
+skipped save does not move the article in any ordering by `updated_at`.
 
 `publish_time` SHALL NOT be written from any source other than the `time` field of the Luogu article
 payload.
@@ -256,8 +270,12 @@ payload.
    another. `publish_time` is the instant Luogu reports for the article itself; `created_at` is the
    instant this system first persisted the row. For an article archived long after publication the
    two differ without bound.
-6. `publish_time` is `NULL` if and only if no successful save has written it for that article. It is
-   never `0` and never derived from `created_at`.
+6. `publish_time` is `NULL` if and only if no save has yet observed a Luogu `time` that
+   `normalizePublishTime` accepts for that article. It is never `0` and never derived from
+   `created_at`.
+7. Writing `publish_time` into a row that stored `NULL` is not an update of the archived article.
+   It SHALL NOT advance `updated_at`, because `updated_at` orders `GET /article/recent` of section
+   4.4 and is read by clients as the instant the archived content last changed.
 
 ## 9. Summary Rebuild Workflow
 

--- a/spec/paste-system.spec.md
+++ b/spec/paste-system.spec.md
@@ -153,12 +153,17 @@ When a cached read method receives a manager argument, it SHALL bypass Redis cac
 
 #### saveLuoguPaste(data: LuoguPaste, forceUpdate = false): Promise<{ skipped: boolean; content: string }>
 
+Let `t = normalizePublishTime(data.time)`, defined in section 7.1 of the article system
+specification: `t` equals `data.time` when that value is an integer satisfying
+`1 <= data.time <= 4294967295`, and is `null` otherwise.
+
 1. Compute `SHA-256(data.data)`.
-2. If a paste with `id=data.id` exists, `forceUpdate=false`, and `content_hash` equals the computed hash, return `{ skipped: true, content: "" }` without updating the database.
-3. Otherwise upsert a paste row with `id=data.id`, `content=data.data`, `author_id=data.user.uid`, `publish_time=data.time`, `content_hash` equal to the computed hash, and `deleted=false` for newly inserted rows.
+2. If a paste with `id=data.id` exists, `forceUpdate=false`, and `content_hash` equals the computed hash, run the backfill of step 7 and return `{ skipped: true, content: "" }` without otherwise updating the database.
+3. Otherwise upsert a paste row with `id=data.id`, `content=data.data`, `author_id=data.user.uid`, `publish_time=t`, `content_hash` equal to the computed hash, and `deleted=false` for newly inserted rows. If `t` is `null`, `publish_time` SHALL be absent from the upsert payload, so that a malformed `time` neither inserts nor overwrites a value.
 4. Return `{ skipped: false, content }` where `content` equals the saved paste content.
 5. A missing paste row SHALL be inserted before any pessimistic row lock is requested.
 6. MariaDB deadlock and lock-wait timeout errors SHALL retry the complete paste transaction at most three times.
+7. When step 2 skips and `t` is not `null`, execute exactly one additional statement inside the same transaction: `UPDATE paste SET publish_time = :t WHERE id = :id AND publish_time IS NULL`. It SHALL leave `updated_at` unchanged and SHALL affect zero rows once `publish_time` is set.
 
 ## 5. Content Rendering
 
@@ -205,10 +210,11 @@ The default value for `delete_reason` is `'管理员删除'` (Administrator dele
 4. `publish_time` and `created_at` denote different instants and SHALL NOT be substituted for one
    another. `publish_time` is the instant Luogu reports for the paste itself; `created_at` is the
    instant this system first persisted the row.
-5. `publish_time` is `NULL` if and only if no successful save has written it for that paste. It is
-   never `0` and never derived from `created_at`. Step 2 of `saveLuoguPaste` returns without
-   writing, so a row inserted before this column existed retains `NULL` until the next save that is
-   not skipped; callers that need the value SHALL request `forceUpdate = true`.
+5. `publish_time` is `NULL` if and only if no save has yet observed a Luogu `time` that
+   `normalizePublishTime` accepts for that paste. It is never `0` and never derived from
+   `created_at`.
+6. Writing `publish_time` into a row that stored `NULL` is not an update of the archived paste and
+   SHALL NOT advance `updated_at`.
 
 ## 8. File Locations
 


### PR DESCRIPTION
Closes #83. Follow-up to #77, which added the column but reaches almost no existing row.

`publish_time` is written only by a save that reaches the write, and `saveHashedContent` returns early whenever the stored content hash and title both match. Archived documents rarely change, so almost every save of an existing row is skipped and the column stays `NULL`: 13 of the 20 rows returned by `GET /article/recent` still report `publishTime: null` today, several archived months ago and saved again since. A row only ever gains its publish time if its content happens to change or a caller passes `forceUpdate` — which the public `paste-save-pipeline` template does not forward at all.

This fills it on the skipped path. The save already fetched the payload and already holds the pessimistic row lock, so it costs one statement:

```sql
UPDATE article SET publish_time = ? WHERE id = ? AND publish_time IS NULL
```

## Changes

- `services/helpers/publish-time.helper.ts` (new) — `normalizePublishTime` and `backfillPublishTime`.
- `services/article.service.ts`, `services/paste.service.ts` — run the backfill on the skipped path, and pass `data.time` through the normalizer before writing it.
- `test/publish-time.test.ts` (new) — behavioural tests against a real in-memory SQL engine.
- `spec/article-system.spec.md`, `spec/paste-system.spec.md` — save semantics and invariants.

## Notes on the choices

**`WHERE publish_time IS NULL` rather than reading the value first.** The predicate carries the correctness: the statement cannot overwrite a stored value, so no extra read is needed and a concurrent writer cannot lose one. It also makes the statement idempotent — it affects zero rows once the column is set. The cost is one primary-key update per skipped save, on a row whose lock this transaction already holds, next to an HTTP fetch the same task already performed.

**`updated_at` is left alone**, by assigning the column to itself to suppress the `= CURRENT_TIMESTAMP` that `UpdateQueryBuilder` appends otherwise. Giving a row a publish time it always had is not an update of the archived document: `updated_at` orders `GET /article/recent`, is shown to readers as the moment the archived content last changed, and is the cursor that search reindexing pages through. Without this, every backfilled article would jump to the top of the recent list once.

**Not by widening `isUnchanged`.** Treating a `NULL` publish time as "changed" would have been a one-line diff, but it routes the row through the full update path and pushes an `article_history` version byte-identical to the one already stored.

**Both write mappings now normalize.** `normalizePublishTime` accepts only an integer in `[1, 4294967295]`, the range of the column. The specs already stated that `publish_time` is never `0` and never fabricated, but the mappings wrote the payload field unchecked, so a `0` or an out-of-range `time` would have been stored — and on the update path could have replaced a good value. An unusable `time` is now absent from the payload instead of overwriting it with `null`.

**No new dependency and no config change.** The test drives the helper through TypeORM's `sqljs` driver over `sql.js`, both already present in `packages/backend`.

## Verification

- `npm run lint:eslint`, `npm run lint:prettier` — clean.
- `npx vue-tsc -p packages/frontend/tsconfig.app.json --noEmit` — clean.
- `npm test` — backend 13, frontend 8, markdown-renderer 19, all passing.
- `npm run build` for all three workspaces, and `npm audit --omit=dev --audit-level=critical` — clean.

The new tests cover the fill, the untouched update date, the refusal to overwrite an existing value, idempotence across repeated skipped saves, rejection of unusable input, and that no other row is touched. I checked that each one is load-bearing by removing the behaviour it guards — dropping the update-date suppression, the `IS NULL` predicate, the `id` in the criteria, and each bound of the normalizer — and confirming the matching assertion fails every time.

Not verified: no run against MariaDB, so the dialect-specific part is the identifier quoting that `driver.escape` produces. The two service call sites are covered by the type checker and the specs only; a test at that level would need vitest to resolve the `@/` alias, which is still not configured, and I would rather not widen this change into the test setup.
