### PR TITLE
fix(paste): forward forceUpdate through the paste save pipeline

### DIFF
--- a/packages/backend/src/lib/workflow-templates.ts
+++ b/packages/backend/src/lib/workflow-templates.ts
@@ -180,6 +180,7 @@ export const WORKFLOW_TEMPLATES: Record<string, WorkflowTemplateBuilder> = {
         if (!targetId) {
             throw new Error('targetId is required for paste-save-pipeline');
         }
+        const forceUpdate = params?.forceUpdate === true;
 
         const tasks: TaskDefinition[] = [
             {
@@ -191,7 +192,7 @@ export const WORKFLOW_TEMPLATES: Record<string, WorkflowTemplateBuilder> = {
                     payload: {
                         target: 'paste',
                         targetId: targetId,
-                        metadata: {}
+                        metadata: { forceUpdate }
                     }
                 }
             },

--- a/spec/paste-system.spec.md
+++ b/spec/paste-system.spec.md
@@ -99,7 +99,8 @@ Input body:
 
 ```json
 {
-    "targetId": "paste_id"
+    "targetId": "paste_id",
+    "forceUpdate": false
 }
 ```
 
@@ -107,12 +108,13 @@ Postconditions:
 
 1. If `targetId` is absent or empty, workflow creation SHALL fail.
 2. The template SHALL be public and require no authentication.
-3. The workflow SHALL contain one reported task named `save` with type `save`, target `paste`, and `targetId` equal to the input `targetId`.
+3. The workflow SHALL contain one reported task named `save` with type `save`, target `paste`, `targetId` equal to the input `targetId`, and metadata `{ "forceUpdate": f }`, where `f` is `true` only when the input `forceUpdate` is exactly boolean `true` and `false` for every other value including its absence.
 4. Workflow creation SHALL use deduplication key `paste-save:${targetId}` and return the active existing workflow descriptor when that key already exists.
 5. The workflow MAY contain content safety tasks for the saved paste.
 6. The workflow SHALL NOT contain an LLM task with target `summary`.
 7. The workflow SHALL NOT contain an LLM task with target `embedding`.
 8. The workflow SHALL NOT contain an update task with target `search_index`.
+9. The `save` task SHALL reach `saveLuoguPaste` with `forceUpdate = f`. This endpoint is the only public way to refresh one stored paste, so when `f` is `true` a paste whose content hash is unchanged SHALL still be written.
 
 ## 4. Service Layer
 

--- a/spec/workflow-system.spec.md
+++ b/spec/workflow-system.spec.md
@@ -194,7 +194,8 @@ For every returned task with `status = "failed"`, `info` is normalized by `task-
 
 ### 5.1 `article-save-pipeline`
 
-Required input: `targetId`.
+Required input: `targetId`. Optional input: `forceUpdate`, which is `true` only when the input value
+is exactly boolean `true`, and `false` for every other value including its absence.
 
 Task graph by logical dependency:
 
@@ -219,11 +220,15 @@ Task `update-embedding` SHALL read upstream `embedding.data.embeddingRecords` an
 Task `update-embedding` SHALL NOT call any LLM provider.
 Task `update-embedding` SHALL NOT depend on `update-summary`.
 
+Task `save` has metadata `{ "forceUpdate": <the normalized input value> }`, which
+`ArticleService.saveLuoguArticle` reads to decide whether an unchanged content hash still writes the
+row.
+
 Task `update-search-index` has `track=true` and `report=true` so clients can observe final search indexing success or failure.
 
 ### 5.2 `paste-save-pipeline`
 
-Required input: `targetId`.
+Required input: `targetId`. Optional input: `forceUpdate`, normalized exactly as in section 5.1.
 
 Task graph by logical dependency:
 
@@ -233,7 +238,9 @@ Task graph by logical dependency:
 
 Permission: public (`null` permission mapping).
 
-Task `save` has type `save`, target `paste`, targetId equal to the input `targetId`, and empty metadata.
+Task `save` has type `save`, target `paste`, targetId equal to the input `targetId`, and metadata
+`{ "forceUpdate": <the normalized input value> }`, which `PasteService.saveLuoguPaste` reads to
+decide whether an unchanged content hash still writes the row.
 Task `censor` has type `llm`, target `censor`, and empty metadata.
 Task `update-censor` has type `update`, target `censor`, targetId equal to the input `targetId`, and metadata `{ "censorTarget": "paste" }`.
 


### PR DESCRIPTION
Closes #85.

`POST /workflow/create/template/paste-save-pipeline` accepts a `forceUpdate` flag the way its article counterpart does, but the template builds the `save` task with `metadata: {}`, so the flag never reaches the task. Everything downstream was already in place — `SaveTask` declares `metadata.forceUpdate`, and `PasteHandler` reads `task.payload.metadata?.forceUpdate` and passes it to `PasteService.saveLuoguPaste` — only the template dropped it.

The consequence is that no caller of the public API can refresh a stored paste. `saveLuoguPaste` returns early whenever the content hash matches, and this endpoint is the only public way to reach it, so a paste row is effectively frozen after its first archive: the request creates a workflow, the workflow runs, the task reports success, and not one byte of the row is rewritten.

## Changes

- `lib/workflow-templates.ts` — normalize `forceUpdate` with `params?.forceUpdate === true` and put it in the `save` task metadata, exactly as `article-save-pipeline` does.
- `spec/workflow-system.spec.md` — document the optional input and the `save` task metadata for both save pipelines. Section 5.1 previously did not state the article template's metadata either, so this also brings that section in line with the code it already describes.
- `spec/paste-system.spec.md` — the endpoint's input body and one postcondition.

## Notes

**Deduplication is unchanged.** The key is still `paste-save:${targetId}` with no reference to `forceUpdate`, so a forcing request that deduplicates onto an active non-forcing workflow still runs without the flag. `article-save-pipeline` behaves the same way today, and making the two diverge felt like it belongs in its own change rather than being smuggled in here.

**The frontend is unchanged.** `savePaste()` and `saveArticle()` both send only `targetId`, and this does not alter what either of them does.

## Verification

- `npm run lint:eslint`, `npm run lint:prettier` — clean.
- `npx vue-tsc -p packages/frontend/tsconfig.app.json --noEmit` — clean.
- `npm test` — backend 5, frontend 8, markdown-renderer 19, all passing.
- `npm run build` for all three workspaces — clean.

No test accompanies this change, and I would rather say why than leave it unexplained. A unit test would have to import `lib/workflow-templates.ts`, which needs two things this repository does not have: vitest resolving the `@/` alias, and a readable `config.yml`, because that module imports `@/config`, whose `findConfigPath()` throws at module load when no config file is found — and no config file is committed. Both are fixable, but doing either inside a two-line fix would make the change mostly test scaffolding. I am happy to open a separate PR adding a `vitest.config.ts` alias if that would be welcome, which would also let the save services be tested directly.
