### PR TITLE
feat(judgement): optimize API responses, filters, docs, and responsive UI

### DIFF
--- a/packages/backend/src/services/judgement.service.ts
+++ b/packages/backend/src/services/judgement.service.ts
@@ -144,6 +144,17 @@ export class JudgementService {
                 name: `%${escapeLikeLiteral(query.name)}%`
             });
         }
+        if (query.reason) {
+            builder.andWhere("record.reason LIKE :reason ESCAPE '!'", {
+                reason: `%${escapeLikeLiteral(query.reason)}%`
+            });
+        }
+        if (query.startTime !== undefined) {
+            builder.andWhere('record.time >= :startTime', { startTime: query.startTime });
+        }
+        if (query.endTime !== undefined) {
+            builder.andWhere('record.time <= :endTime', { endTime: query.endTime });
+        }
         if (query.noPermission) {
             builder.andWhere('record.revoked_permission = 0');
             builder.andWhere('record.added_permission = 0');

--- a/packages/backend/src/services/judgement.service.ts
+++ b/packages/backend/src/services/judgement.service.ts
@@ -5,6 +5,7 @@ import { logger } from '@/lib/logger';
 import {
     createJudgementDedupKey,
     escapeLikeLiteral,
+    toJudgementListItem,
     type JudgementPaginationQuery,
     type JudgementQuery,
     type LuoguJudgementRecord,
@@ -119,6 +120,18 @@ export class JudgementService {
     static async list(query: JudgementQuery) {
         const builder = JudgementRecord.getRepository()
             .createQueryBuilder('record')
+            .select([
+                'record.id',
+                'record.uid',
+                'record.name',
+                'record.reason',
+                'record.revokedPermission',
+                'record.addedPermission',
+                'record.time',
+                'record.userSnapshot',
+                'record.fetchLogId',
+                'record.createdAt'
+            ])
             .leftJoinAndSelect('record.fetchLog', 'fetchLog')
             .orderBy('record.time', 'DESC')
             .addOrderBy('record.id', 'DESC')
@@ -150,20 +163,7 @@ export class JudgementService {
 
         const [records, total] = await builder.getManyAndCount();
         return {
-            items: records.map(record => ({
-                id: record.id,
-                uid: record.uid,
-                name: record.name,
-                reason: record.reason,
-                revoked_permission: record.revokedPermission,
-                added_permission: record.addedPermission,
-                time: record.time,
-                user: record.userSnapshot,
-                full_record: record.fullRecord,
-                fetch_log_id: record.fetchLogId,
-                log_fetched_at: record.fetchLog?.fetchedAt ?? null,
-                created_at: record.createdAt
-            })),
+            items: records.map(toJudgementListItem),
             pagination: {
                 page: query.page,
                 limit: query.limit,

--- a/packages/backend/src/shared/judgement.ts
+++ b/packages/backend/src/shared/judgement.ts
@@ -47,6 +47,36 @@ export interface JudgementPaginationQuery {
     limit: number;
 }
 
+interface JudgementListRecord {
+    id: number;
+    uid: number;
+    name: string;
+    reason: string | null;
+    revokedPermission: number;
+    addedPermission: number;
+    time: number;
+    userSnapshot: Record<string, unknown>;
+    fetchLogId: number;
+    fetchLog?: { fetchedAt: Date } | null;
+    createdAt: Date;
+}
+
+export function toJudgementListItem(record: JudgementListRecord) {
+    return {
+        id: record.id,
+        uid: record.uid,
+        name: record.name,
+        reason: record.reason,
+        revoked_permission: record.revokedPermission,
+        added_permission: record.addedPermission,
+        time: record.time,
+        user: record.userSnapshot,
+        fetch_log_id: record.fetchLogId,
+        log_fetched_at: record.fetchLog?.fetchedAt ?? null,
+        created_at: record.createdAt
+    };
+}
+
 export class JudgementQueryError extends Error {
     status = 400;
 }

--- a/packages/backend/src/shared/judgement.ts
+++ b/packages/backend/src/shared/judgement.ts
@@ -37,6 +37,9 @@ export interface JudgementQuery {
     limit: number;
     uids: number[];
     name?: string;
+    reason?: string;
+    startTime?: number;
+    endTime?: number;
     revokedPermissions: number[];
     addedPermissions: number[];
     noPermission: boolean;
@@ -139,6 +142,12 @@ function parseIntegerList(value: unknown, field: string): number[] {
     return [...new Set(values)];
 }
 
+function parseOptionalInteger(value: unknown, field: string, maximum: number): number | undefined {
+    const raw = singleQueryValue(value, field);
+    if (raw === undefined) return undefined;
+    return parseInteger(raw, field, 1, maximum);
+}
+
 export function parseJudgementPagination(query: Record<string, unknown>): JudgementPaginationQuery {
     return {
         page: parseInteger(query.page, 'page', 1),
@@ -151,6 +160,16 @@ export function parseJudgementQuery(query: Record<string, unknown>): JudgementQu
     const name = rawName?.trim();
     if (name && name.length > 100) throw new JudgementQueryError('name is too long');
 
+    const rawReason = singleQueryValue(query.reason, 'reason');
+    const reason = rawReason?.trim();
+    if (reason && reason.length > 200) throw new JudgementQueryError('reason is too long');
+
+    const startTime = parseOptionalInteger(query.start_time, 'start_time', UINT32_MAX);
+    const endTime = parseOptionalInteger(query.end_time, 'end_time', UINT32_MAX);
+    if (startTime !== undefined && endTime !== undefined && startTime > endTime) {
+        throw new JudgementQueryError('start_time must not exceed end_time');
+    }
+
     const rawNoPermission = singleQueryValue(query.no_perm, 'no_perm');
     if (rawNoPermission !== undefined && rawNoPermission !== '1') {
         throw new JudgementQueryError('no_perm must equal 1');
@@ -160,6 +179,9 @@ export function parseJudgementQuery(query: Record<string, unknown>): JudgementQu
         ...parseJudgementPagination(query),
         uids: parseIntegerList(query.uid, 'uid'),
         name: name || undefined,
+        reason: reason || undefined,
+        startTime,
+        endTime,
         revokedPermissions: parseIntegerList(query.rev_perm, 'rev_perm'),
         addedPermissions: parseIntegerList(query.add_perm, 'add_perm'),
         noPermission: rawNoPermission === '1'

--- a/packages/backend/test/judgement.test.ts
+++ b/packages/backend/test/judgement.test.ts
@@ -84,13 +84,13 @@ describe('judgement domain helpers', () => {
         const fetchedAt = new Date('2026-08-17T00:40:01.838Z');
         const item = toJudgementListItem({
             id: 1540,
-            uid: 1336416,
-            name: 'Qselian',
+            uid: 123456,
+            name: 'ExampleUser',
             reason: 'reason',
             revokedPermission: 32768,
             addedPermission: 0,
             time: 1786942821,
-            userSnapshot: { uid: 1336416, name: 'Qselian', color: 'Orange' },
+            userSnapshot: { uid: 123456, name: 'ExampleUser', color: 'Orange' },
             fetchLogId: 16,
             fetchLog: { fetchedAt },
             createdAt,
@@ -101,13 +101,13 @@ describe('judgement domain helpers', () => {
 
         expect(item).toEqual({
             id: 1540,
-            uid: 1336416,
-            name: 'Qselian',
+            uid: 123456,
+            name: 'ExampleUser',
             reason: 'reason',
             revoked_permission: 32768,
             added_permission: 0,
             time: 1786942821,
-            user: { uid: 1336416, name: 'Qselian', color: 'Orange' },
+            user: { uid: 123456, name: 'ExampleUser', color: 'Orange' },
             fetch_log_id: 16,
             log_fetched_at: fetchedAt,
             created_at: createdAt

--- a/packages/backend/test/judgement.test.ts
+++ b/packages/backend/test/judgement.test.ts
@@ -30,6 +30,9 @@ describe('judgement domain helpers', () => {
                 limit: '100',
                 uid: '3,3,7',
                 name: '  a%b_!  ',
+                reason: '  spam%_!  ',
+                start_time: '1700000000',
+                end_time: '1800000000',
                 rev_perm: '64,32768',
                 no_perm: '1'
             })
@@ -38,6 +41,9 @@ describe('judgement domain helpers', () => {
             limit: 100,
             uids: [3, 7],
             name: 'a%b_!',
+            reason: 'spam%_!',
+            startTime: 1_700_000_000,
+            endTime: 1_800_000_000,
             revokedPermissions: [64, 32768],
             addedPermissions: [],
             noPermission: true
@@ -50,6 +56,10 @@ describe('judgement domain helpers', () => {
         expect(() => parseJudgementQuery({ limit: '501' })).toThrow();
         expect(() => parseJudgementQuery({ uid: '1,,2' })).toThrow();
         expect(() => parseJudgementQuery({ no_perm: 'true' })).toThrow();
+        expect(() =>
+            parseJudgementQuery({ start_time: '1800000000', end_time: '1700000000' })
+        ).toThrow();
+        expect(() => parseJudgementQuery({ start_time: '4294967296' })).toThrow();
     });
 
     it('validates required upstream fields while preserving snapshots', () => {

--- a/packages/backend/test/judgement.test.ts
+++ b/packages/backend/test/judgement.test.ts
@@ -3,7 +3,8 @@ import {
     createJudgementDedupKey,
     escapeLikeLiteral,
     LuoguJudgementResponseSchema,
-    parseJudgementQuery
+    parseJudgementQuery,
+    toJudgementListItem
 } from '../src/shared/judgement';
 
 describe('judgement domain helpers', () => {
@@ -66,6 +67,42 @@ describe('judgement domain helpers', () => {
         });
         expect(parsed.logs[0].user.color).toBe('Blue');
         expect(parsed.logs[0].extra).toBe('preserved');
+    });
+
+    it('omits the complete record snapshot from list items', () => {
+        const createdAt = new Date('2026-08-17T00:40:01.938Z');
+        const fetchedAt = new Date('2026-08-17T00:40:01.838Z');
+        const item = toJudgementListItem({
+            id: 1540,
+            uid: 1336416,
+            name: 'Qselian',
+            reason: 'reason',
+            revokedPermission: 32768,
+            addedPermission: 0,
+            time: 1786942821,
+            userSnapshot: { uid: 1336416, name: 'Qselian', color: 'Orange' },
+            fetchLogId: 16,
+            fetchLog: { fetchedAt },
+            createdAt,
+            fullRecord: { duplicated: true }
+        } as Parameters<typeof toJudgementListItem>[0] & {
+            fullRecord: Record<string, unknown>;
+        });
+
+        expect(item).toEqual({
+            id: 1540,
+            uid: 1336416,
+            name: 'Qselian',
+            reason: 'reason',
+            revoked_permission: 32768,
+            added_permission: 0,
+            time: 1786942821,
+            user: { uid: 1336416, name: 'Qselian', color: 'Orange' },
+            fetch_log_id: 16,
+            log_fetched_at: fetchedAt,
+            created_at: createdAt
+        });
+        expect(item).not.toHaveProperty('full_record');
     });
 
     it('rejects upstream values that cannot fit unsigned database columns', () => {

--- a/packages/frontend/src/api/judgement-query.ts
+++ b/packages/frontend/src/api/judgement-query.ts
@@ -3,6 +3,9 @@ export interface JudgementQueryParams {
     limit?: number;
     uid?: number[];
     name?: string;
+    reason?: string;
+    start_time?: number;
+    end_time?: number;
     rev_perm?: number[];
     add_perm?: number[];
     no_perm?: number;

--- a/packages/frontend/src/api/judgement.ts
+++ b/packages/frontend/src/api/judgement.ts
@@ -11,7 +11,6 @@ export interface JudgementItem {
     added_permission: number;
     time: number;
     user: JudgementUser;
-    full_record: Record<string, unknown>;
     fetch_log_id: number;
     log_fetched_at: string | null;
     created_at: string;

--- a/packages/frontend/src/utils/api-base-url.ts
+++ b/packages/frontend/src/utils/api-base-url.ts
@@ -1,5 +1,15 @@
 export const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 
+export function resolvePublicApiBaseUrl(apiBaseUrl: string, pageOrigin: string): string {
+    const baseWithTrailingSlash = `${apiBaseUrl.replace(/\/$/, '')}/`;
+    return new URL(baseWithTrailingSlash, `${pageOrigin.replace(/\/$/, '')}/`).href;
+}
+
+export function getPublicApiBaseUrl(): string {
+    if (typeof window === 'undefined') return API_BASE_URL;
+    return resolvePublicApiBaseUrl(API_BASE_URL, window.location.origin);
+}
+
 export function getApiUrl(path: string): string {
     const normalizedPath = path.startsWith('/') ? path : `/${path}`;
     return `${API_BASE_URL.replace(/\/$/, '')}${normalizedPath}`;

--- a/packages/frontend/src/views/judgement/JudgementLogsView.vue
+++ b/packages/frontend/src/views/judgement/JudgementLogsView.vue
@@ -16,6 +16,10 @@ import { getPublicApiBaseUrl } from '@/utils/api-base-url.ts';
 import { formatDate } from '@/utils/render.ts';
 
 const publicApiBaseUrl = getPublicApiBaseUrl();
+const judgementEndpoint = `${publicApiBaseUrl}judgement`;
+const judgementRequestFormat = `${judgementEndpoint}?page={page}&limit={limit}&uid={uid}&name={name}&rev_perm={rev_perm}&add_perm={add_perm}&no_perm=1`;
+const judgementRequestExample = `${judgementEndpoint}?page=1&limit=50&uid=1336416&name=Qselian&rev_perm=32768`;
+const judgementNoPermissionExample = `${judgementEndpoint}?page=1&limit=50&no_perm=1`;
 const loading = ref(false);
 const errorMessage = ref<string | null>(null);
 const logs = ref<JudgementFetchLogItem[]>([]);
@@ -151,17 +155,96 @@ onMounted(() => void loadData());
         </Card>
 
         <Card class="api-card" title="公开 API">
-            <p>Base URL: {{ publicApiBaseUrl }}</p>
-            <ul>
+            <p>
+                Base URL: <code>{{ publicApiBaseUrl }}</code>
+            </p>
+            <ul class="endpoint-list">
                 <li><code>GET /judgement</code>：权限变更记录与筛选</li>
                 <li><code>GET /judgement/logs</code>：同步日志</li>
                 <li><code>GET /judgement/stats</code>：记录与抓取统计</li>
             </ul>
-            <p>
-                记录接口支持
-                <code>page</code>、<code>limit</code>、<code>uid</code>、<code>name</code>、
-                <code>rev_perm</code>、<code>add_perm</code> 和 <code>no_perm=1</code>。
-            </p>
+
+            <section class="record-api-docs">
+                <h3>记录接口</h3>
+                <p><code>GET /judgement</code></p>
+
+                <h4>调用格式</h4>
+                <code class="request-url">{{ judgementRequestFormat }}</code>
+
+                <h4>调用示例</h4>
+                <p class="example-label">按 UID、名称和撤销权限筛选：</p>
+                <code class="request-url">{{ judgementRequestExample }}</code>
+                <p class="example-label">仅查询没有权限变更的记录：</p>
+                <code class="request-url">{{ judgementNoPermissionExample }}</code>
+
+                <h4>查询参数</h4>
+                <div class="parameter-table-wrap">
+                    <table class="parameter-table">
+                        <thead>
+                            <tr>
+                                <th>参数</th>
+                                <th>类型与格式</th>
+                                <th>默认值</th>
+                                <th>说明</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><code>page</code></td>
+                                <td>正整数</td>
+                                <td><code>1</code></td>
+                                <td>页码，从 1 开始。</td>
+                            </tr>
+                            <tr>
+                                <td><code>limit</code></td>
+                                <td>1–500 的整数</td>
+                                <td><code>50</code></td>
+                                <td>每页返回的记录数量。</td>
+                            </tr>
+                            <tr>
+                                <td><code>uid</code></td>
+                                <td>正整数；多值用英文逗号分隔</td>
+                                <td>不筛选</td>
+                                <td>匹配任意一个 UID，例如 <code>123,456</code>。</td>
+                            </tr>
+                            <tr>
+                                <td><code>name</code></td>
+                                <td>字符串，最长 100 个字符</td>
+                                <td>不筛选</td>
+                                <td>按用户名进行字面子串匹配。</td>
+                            </tr>
+                            <tr>
+                                <td><code>rev_perm</code></td>
+                                <td>正整数权限位；多值用英文逗号分隔</td>
+                                <td>不筛选</td>
+                                <td>
+                                    撤销权限必须包含所有指定权限位，例如 <code>64,32768</code>。
+                                </td>
+                            </tr>
+                            <tr>
+                                <td><code>add_perm</code></td>
+                                <td>正整数权限位；多值用英文逗号分隔</td>
+                                <td>不筛选</td>
+                                <td>新增权限必须包含所有指定权限位。</td>
+                            </tr>
+                            <tr>
+                                <td><code>no_perm</code></td>
+                                <td>固定值 <code>1</code></td>
+                                <td>不筛选</td>
+                                <td>
+                                    设为 <code>1</code> 时，仅返回撤销权限和新增权限都等于 0
+                                    的记录。
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <p class="parameter-note">
+                    所有已提供的筛选条件按 AND 组合。权限值使用权限位数字，例如
+                    <code>64</code> 表示秩序管理，<code>32768</code> 表示自由发言。
+                </p>
+            </section>
         </Card>
     </div>
 </template>
@@ -213,18 +296,92 @@ onMounted(() => void loadData());
     margin: 0 0 10px;
     line-height: 1.7;
 }
-.api-card p:last-child {
-    margin-bottom: 0;
-}
-.api-card ul {
-    margin: 0 0 10px;
+.endpoint-list {
+    margin: 0;
     padding-left: 22px;
     line-height: 1.8;
+}
+.record-api-docs {
+    margin-top: 20px;
+    padding-top: 18px;
+    border-top: 1px solid var(--ui-border-color);
+}
+.record-api-docs h3,
+.record-api-docs h4 {
+    margin: 0;
+    font-size: 16px;
+}
+.record-api-docs h3 {
+    margin-bottom: 8px;
+    font-size: 18px;
+}
+.record-api-docs h4 {
+    margin-top: 18px;
+    margin-bottom: 8px;
 }
 .api-card code {
     padding: 2px 5px;
     border-radius: 4px;
     background: var(--ui-panel-color);
+}
+.request-url {
+    display: block;
+    padding: 10px 12px !important;
+    overflow-wrap: anywhere;
+    line-height: 1.6;
+}
+.example-label {
+    margin: 10px 0 6px !important;
+    color: var(--ui-secondary-text-color);
+}
+.parameter-table-wrap {
+    width: 100%;
+    overflow-x: auto;
+    border: 1px solid var(--ui-border-color);
+    border-radius: 6px;
+}
+.parameter-table {
+    width: 100%;
+    min-width: 780px;
+    border-collapse: collapse;
+    line-height: 1.55;
+}
+.parameter-table th,
+.parameter-table td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--ui-border-color);
+    text-align: left;
+    vertical-align: top;
+}
+.parameter-table th {
+    background: var(--ui-panel-color);
+    font-size: 13px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+.parameter-table tbody tr {
+    transition: background-color 0.2s ease;
+}
+.parameter-table tbody tr:hover {
+    background: var(--ui-panel-color);
+}
+.parameter-table tbody tr:last-child td {
+    border-bottom: 0;
+}
+.parameter-table td:first-child {
+    width: 110px;
+}
+.parameter-table td:nth-child(2) {
+    width: 230px;
+}
+.parameter-table td:nth-child(3) {
+    width: 100px;
+    white-space: nowrap;
+}
+.parameter-note {
+    margin-top: 12px !important;
+    margin-bottom: 0 !important;
+    color: var(--ui-secondary-text-color);
 }
 @media (max-width: 768px) {
     .summary-grid {

--- a/packages/frontend/src/views/judgement/JudgementLogsView.vue
+++ b/packages/frontend/src/views/judgement/JudgementLogsView.vue
@@ -17,8 +17,8 @@ import { formatDate } from '@/utils/render.ts';
 
 const publicApiBaseUrl = getPublicApiBaseUrl();
 const judgementEndpoint = `${publicApiBaseUrl}judgement`;
-const judgementRequestFormat = `${judgementEndpoint}?page={page}&limit={limit}&uid={uid}&name={name}&rev_perm={rev_perm}&add_perm={add_perm}&no_perm=1`;
-const judgementRequestExample = `${judgementEndpoint}?page=1&limit=50&uid=1336416&name=Qselian&rev_perm=32768`;
+const judgementRequestFormat = `${judgementEndpoint}?page={page}&limit={limit}&uid={uid}&name={name}&reason={reason}&start_time={start_time}&end_time={end_time}&rev_perm={rev_perm}&add_perm={add_perm}&no_perm=1`;
+const judgementRequestExample = `${judgementEndpoint}?page=1&limit=50&uid=123456&name=ExampleUser&reason=违规&start_time=1700000000&end_time=1800000000&rev_perm=32768`;
 const judgementNoPermissionExample = `${judgementEndpoint}?page=1&limit=50&no_perm=1`;
 const loading = ref(false);
 const errorMessage = ref<string | null>(null);
@@ -172,7 +172,7 @@ onMounted(() => void loadData());
                 <code class="request-url">{{ judgementRequestFormat }}</code>
 
                 <h4>调用示例</h4>
-                <p class="example-label">按 UID、名称和撤销权限筛选：</p>
+                <p class="example-label">按 UID、用户名、原因、时间段和撤销权限筛选：</p>
                 <code class="request-url">{{ judgementRequestExample }}</code>
                 <p class="example-label">仅查询没有权限变更的记录：</p>
                 <code class="request-url">{{ judgementNoPermissionExample }}</code>
@@ -214,6 +214,24 @@ onMounted(() => void loadData());
                                 <td>按用户名进行字面子串匹配。</td>
                             </tr>
                             <tr>
+                                <td><code>reason</code></td>
+                                <td>字符串，最长 200 个字符</td>
+                                <td>不筛选</td>
+                                <td>按原因进行字面子串匹配。</td>
+                            </tr>
+                            <tr>
+                                <td><code>start_time</code></td>
+                                <td>1–4294967295 的 Unix 秒</td>
+                                <td>不限制下界</td>
+                                <td>仅返回记录时间大于或等于该值的记录。</td>
+                            </tr>
+                            <tr>
+                                <td><code>end_time</code></td>
+                                <td>1–4294967295 的 Unix 秒</td>
+                                <td>不限制上界</td>
+                                <td>仅返回记录时间小于或等于该值的记录。</td>
+                            </tr>
+                            <tr>
                                 <td><code>rev_perm</code></td>
                                 <td>正整数权限位；多值用英文逗号分隔</td>
                                 <td>不筛选</td>
@@ -242,7 +260,10 @@ onMounted(() => void loadData());
 
                 <p class="parameter-note">
                     所有已提供的筛选条件按 AND 组合。权限值使用权限位数字，例如
-                    <code>64</code> 表示秩序管理，<code>32768</code> 表示自由发言。
+                    <code>64</code> 表示秩序管理，<code>32768</code>
+                    表示自由发言。时间边界均被包含；可只提供 <code>start_time</code> 或
+                    <code>end_time</code>，同时提供时 <code>start_time</code> 不得大于
+                    <code>end_time</code>。
                 </p>
             </section>
         </Card>

--- a/packages/frontend/src/views/judgement/JudgementLogsView.vue
+++ b/packages/frontend/src/views/judgement/JudgementLogsView.vue
@@ -12,8 +12,10 @@ import {
     type JudgementFetchLogItem,
     type JudgementStats
 } from '@/api/judgement.ts';
+import { getPublicApiBaseUrl } from '@/utils/api-base-url.ts';
 import { formatDate } from '@/utils/render.ts';
 
+const publicApiBaseUrl = getPublicApiBaseUrl();
 const loading = ref(false);
 const errorMessage = ref<string | null>(null);
 const logs = ref<JudgementFetchLogItem[]>([]);
@@ -149,7 +151,7 @@ onMounted(() => void loadData());
         </Card>
 
         <Card class="api-card" title="公开 API">
-            <p>Base URL: https://api.luogu.me/</p>
+            <p>Base URL: {{ publicApiBaseUrl }}</p>
             <ul>
                 <li><code>GET /judgement</code>：权限变更记录与筛选</li>
                 <li><code>GET /judgement/logs</code>：同步日志</li>

--- a/packages/frontend/src/views/judgement/JudgementView.vue
+++ b/packages/frontend/src/views/judgement/JudgementView.vue
@@ -8,6 +8,7 @@ import {
     NCheckbox,
     NCheckboxGroup,
     NDataTable,
+    NDatePicker,
     NEmpty,
     NIcon,
     NInput,
@@ -47,9 +48,12 @@ const limit = ref(DEFAULT_PAGE_SIZE);
 const expandedPanel = ref<ExpandedPanel>(null);
 const filterUid = ref<number | null>(null);
 const filterName = ref('');
+const filterReason = ref('');
+const filterTimeRange = ref<[number, number] | null>(null);
 const filterRevPerm = ref<number[]>([]);
 const filterAddPerm = ref<number[]>([]);
 const filterNoPerm = ref(false);
+const mobileViewport = ref(false);
 let latestRequestId = 0;
 let refreshTimer: ReturnType<typeof setInterval> | null = null;
 
@@ -137,12 +141,34 @@ function renderUser(row: JudgementItem) {
     return h('div', { class: 'user-cell' }, children);
 }
 
+function renderMobileUser(row: JudgementItem) {
+    return h('div', { class: 'mobile-user-cell' }, [
+        h('img', {
+            class: 'user-avatar',
+            src: `https://cdn.luogu.com.cn/upload/usericon/${row.uid}.png`,
+            alt: `${row.name} 的头像`,
+            loading: 'lazy'
+        }),
+        h('div', { class: 'mobile-user-details' }, [
+            renderUser(row),
+            h('span', { class: 'mobile-user-uid' }, `UID ${row.uid}`)
+        ])
+    ]);
+}
+
+function updateMobileViewport() {
+    mobileViewport.value = window.innerWidth <= 768;
+}
+
 function buildQueryParams() {
     return {
         page: page.value,
         limit: limit.value,
         uid: filterUid.value === null ? undefined : [filterUid.value],
         name: filterName.value.trim() || undefined,
+        reason: filterReason.value.trim() || undefined,
+        start_time: filterTimeRange.value ? Math.floor(filterTimeRange.value[0] / 1000) : undefined,
+        end_time: filterTimeRange.value ? Math.floor(filterTimeRange.value[1] / 1000) : undefined,
         rev_perm: filterRevPerm.value.length > 0 ? filterRevPerm.value : undefined,
         add_perm: filterAddPerm.value.length > 0 ? filterAddPerm.value : undefined,
         no_perm: filterNoPerm.value ? 1 : undefined
@@ -191,6 +217,8 @@ function handleSearch() {
 function handleReset() {
     filterUid.value = null;
     filterName.value = '';
+    filterReason.value = '';
+    filterTimeRange.value = null;
     filterRevPerm.value = [];
     filterAddPerm.value = [];
     filterNoPerm.value = false;
@@ -209,6 +237,32 @@ function handleLimitChange(nextLimit: number) {
 
 const columns = computed<DataTableColumns<JudgementItem>>(() => {
     const result: DataTableColumns<JudgementItem> = [];
+    if (mobileViewport.value) {
+        result.push({ title: '用户', key: 'name', width: 180, render: renderMobileUser });
+        result.push({
+            title: '权限变更',
+            key: 'permissions',
+            width: 150,
+            render: renderPermissionChanges
+        });
+        if (displayOptions.value.reason) {
+            result.push({
+                title: '原因',
+                key: 'reason',
+                width: 240,
+                render: row => row.reason || '-'
+            });
+        }
+        if (displayOptions.value.time) {
+            result.push({
+                title: '时间',
+                key: 'time',
+                width: 160,
+                render: row => formatDate(row.time * 1000)
+            });
+        }
+        return result;
+    }
     if (displayOptions.value.uid) result.push({ title: 'UID', key: 'uid', width: 100 });
     if (displayOptions.value.avatar) {
         result.push({
@@ -263,11 +317,14 @@ const columns = computed<DataTableColumns<JudgementItem>>(() => {
 const paginationVisible = computed(() => total.value > limit.value);
 
 onMounted(() => {
+    updateMobileViewport();
+    window.addEventListener('resize', updateMobileViewport);
     void loadJudgements();
     refreshTimer = setInterval(() => void loadJudgements(), 60_000);
 });
 
 onUnmounted(() => {
+    window.removeEventListener('resize', updateMobileViewport);
     if (refreshTimer) clearInterval(refreshTimer);
 });
 </script>
@@ -298,6 +355,25 @@ onUnmounted(() => {
                         @keyup.enter="handleSearch"
                     />
                 </div>
+                <div class="filter-item">
+                    <label for="filter-reason">原因</label>
+                    <n-input
+                        id="filter-reason"
+                        v-model:value="filterReason"
+                        placeholder="模糊匹配"
+                        clearable
+                        @keyup.enter="handleSearch"
+                    />
+                </div>
+                <div class="filter-item">
+                    <label>时间段</label>
+                    <n-date-picker
+                        v-model:value="filterTimeRange"
+                        type="datetimerange"
+                        clearable
+                        :actions="['confirm']"
+                    />
+                </div>
             </div>
             <div class="quick-actions">
                 <n-button secondary @click="togglePanel('permissions')">权限筛选</n-button>
@@ -308,6 +384,16 @@ onUnmounted(() => {
                     :options="PAGE_SIZE_OPTIONS"
                     @update:value="handleLimitChange"
                 />
+                <n-button
+                    tag="a"
+                    href="https://www.luogu.com.cn/judgement"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    secondary
+                >
+                    <template #icon><n-icon :component="ExternalLink" /></template>
+                    查看原始页面
+                </n-button>
                 <div class="filter-actions">
                     <n-button type="primary" @click="handleSearch">
                         <template #icon><n-icon :component="Search" /></template>
@@ -384,7 +470,13 @@ onUnmounted(() => {
                     :data="judgements"
                     :bordered="false"
                     :single-line="false"
-                    :scroll-x="1200"
+                    :scroll-x="
+                        mobileViewport
+                            ? 330 +
+                              (displayOptions.reason ? 240 : 0) +
+                              (displayOptions.time ? 160 : 0)
+                            : 1200
+                    "
                     size="small"
                     :row-key="row => row.id"
                 >
@@ -414,6 +506,9 @@ onUnmounted(() => {
 .table-card {
     margin-top: 16px;
 }
+.filter-card {
+    padding: 14px 16px;
+}
 .detail-link {
     display: inline-flex;
     align-items: center;
@@ -429,13 +524,16 @@ onUnmounted(() => {
 }
 .filter-grid {
     display: grid;
-    grid-template-columns: minmax(220px, 380px) minmax(220px, 380px);
-    gap: 10px 12px;
+    grid-template-columns: minmax(120px, 0.7fr) minmax(150px, 0.75fr) minmax(240px, 1.2fr) minmax(
+            280px,
+            1.35fr
+        );
+    gap: 8px 10px;
 }
 .filter-item {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 2px;
 }
 .filter-item label,
 .table-toolbar {
@@ -462,7 +560,7 @@ onUnmounted(() => {
     align-items: center;
     flex-wrap: wrap;
     gap: 8px;
-    margin-top: 10px;
+    margin-top: 8px;
 }
 .limit-select {
     width: 120px;
@@ -477,7 +575,8 @@ onUnmounted(() => {
     background: var(--ui-card-color);
 }
 .permission-expand-panel {
-    grid-template-columns: repeat(3, minmax(180px, 1fr));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 14px 24px;
 }
 .display-expand-panel {
     grid-template-columns: repeat(2, minmax(180px, max-content));
@@ -506,9 +605,23 @@ onUnmounted(() => {
     gap: 4px 12px;
 }
 :deep(.filter-expand-panel .permission-filter-column) {
-    display: flex !important;
-    flex-direction: column;
-    gap: 6px;
+    display: grid !important;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-content: start;
+    gap: 5px 12px;
+}
+:deep(.permission-filter-column > strong) {
+    grid-column: 1 / -1;
+}
+:deep(.permission-expand-panel > .permission-filter-column:last-child) {
+    grid-column: 1 / -1;
+    grid-template-columns: max-content 1fr;
+    align-items: center;
+    padding-top: 10px;
+    border-top: 1px solid var(--ui-border-color);
+}
+:deep(.permission-expand-panel > .permission-filter-column:last-child > strong) {
+    grid-column: auto;
 }
 :deep(.permission-added) {
     color: #52c41a;
@@ -562,10 +675,17 @@ onUnmounted(() => {
     }
     .quick-actions > .n-button,
     .limit-select {
+        min-width: 0;
+        max-width: 100%;
         width: 100%;
     }
-    .limit-select {
-        grid-column: 1 / -1;
+    .quick-actions > .n-button {
+        padding-right: 8px;
+        padding-left: 8px;
+    }
+    .quick-actions > :deep(.n-button .n-button__content) {
+        min-width: 0;
+        white-space: nowrap;
     }
     .filter-actions {
         grid-column: 1 / -1;
@@ -581,6 +701,13 @@ onUnmounted(() => {
     .display-expand-panel {
         grid-template-columns: minmax(0, 1fr);
     }
+    :deep(.filter-expand-panel .permission-filter-column) {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+    :deep(.permission-expand-panel > .permission-filter-column:last-child) {
+        grid-column: auto;
+        grid-template-columns: minmax(0, 1fr);
+    }
     .pagination-wrap {
         justify-content: flex-start;
         overflow-x: auto;
@@ -588,6 +715,30 @@ onUnmounted(() => {
     }
     :deep(.n-data-table-wrapper) {
         overflow-x: auto;
+    }
+    :deep(.n-data-table-th),
+    :deep(.n-data-table-td) {
+        padding-right: 8px !important;
+        padding-left: 8px !important;
+    }
+    :deep(.mobile-user-cell) {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+    :deep(.mobile-user-details) {
+        min-width: 0;
+    }
+    :deep(.mobile-user-uid) {
+        display: block;
+        margin-top: 2px;
+        color: var(--ui-secondary-text-color);
+        font-size: 11px;
+    }
+}
+@media (min-width: 769px) and (max-width: 1080px) {
+    .filter-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
 @media (max-width: 480px) {

--- a/packages/frontend/test/api-base-url.test.ts
+++ b/packages/frontend/test/api-base-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePublicApiBaseUrl } from '../src/utils/api-base-url';
+
+describe('public API base URL', () => {
+    it('resolves the default relative API path against the current page origin', () => {
+        expect(resolvePublicApiBaseUrl('/api', 'http://localhost:5173')).toBe(
+            'http://localhost:5173/api/'
+        );
+    });
+
+    it('preserves an absolute configured API URL', () => {
+        expect(resolvePublicApiBaseUrl('https://api.luogu.me/', 'http://localhost:5173')).toBe(
+            'https://api.luogu.me/'
+        );
+    });
+});

--- a/packages/frontend/test/judgement-query.test.ts
+++ b/packages/frontend/test/judgement-query.test.ts
@@ -9,8 +9,13 @@ describe('judgement query serialization', () => {
                 uid: [12, 34],
                 rev_perm: [64, 32768],
                 name: 'user name',
+                reason: 'spam reason',
+                start_time: 1_700_000_000,
+                end_time: 1_800_000_000,
                 no_perm: undefined
             })
-        ).toBe('page=2&uid=12%2C34&rev_perm=64%2C32768&name=user+name');
+        ).toBe(
+            'page=2&uid=12%2C34&rev_perm=64%2C32768&name=user+name&reason=spam+reason&start_time=1700000000&end_time=1800000000'
+        );
     });
 });

--- a/spec/judgement-system.spec.md
+++ b/spec/judgement-system.spec.md
@@ -91,15 +91,18 @@ The persistence service SHALL not perform upstream HTTP requests or response val
 
 The endpoint SHALL accept these optional filters:
 
-| Query      | Meaning                                                       |
-| ---------- | ------------------------------------------------------------- |
-| `uid`      | Comma-separated unique positive user IDs                      |
-| `name`     | Trimmed literal substring, maximum 100 characters             |
-| `rev_perm` | Comma-separated positive bit masks, all of which must be set  |
-| `add_perm` | Comma-separated positive bit masks, all of which must be set  |
-| `no_perm`  | Exact value `1` requires both permission fields to equal zero |
+| Query        | Meaning                                                               |
+| ------------ | --------------------------------------------------------------------- |
+| `uid`        | Comma-separated unique positive user IDs                              |
+| `name`       | Trimmed literal substring, maximum 100 characters                     |
+| `reason`     | Trimmed literal substring, maximum 200 characters                     |
+| `start_time` | Positive Unix second; record time must be greater than or equal to it |
+| `end_time`   | Positive Unix second; record time must be less than or equal to it    |
+| `rev_perm`   | Comma-separated positive bit masks, all of which must be set          |
+| `add_perm`   | Comma-separated positive bit masks, all of which must be set          |
+| `no_perm`    | Exact value `1` requires both permission fields to equal zero         |
 
-All supplied filters SHALL be combined with AND. `%`, `_`, and the SQL escape character in `name` SHALL be treated literally. Results SHALL be ordered by `time DESC, id DESC`.
+All supplied filters SHALL be combined with AND. `%`, `_`, and the SQL escape character in `name` and `reason` SHALL be treated literally. An omitted time boundary SHALL leave that side of the interval unbounded. If both time boundaries are supplied, `start_time` SHALL NOT exceed `end_time`. Each supplied time boundary SHALL NOT exceed `4294967295`. Results SHALL be ordered by `time DESC, id DESC`.
 
 The endpoint SHALL call `ctx.success` with:
 

--- a/spec/judgement-system.spec.md
+++ b/spec/judgement-system.spec.md
@@ -114,7 +114,6 @@ The endpoint SHALL call `ctx.success` with:
         added_permission: number;
         time: number;
         user: Record<string, unknown>;
-        full_record: Record<string, unknown>;
         fetch_log_id: number;
         log_fetched_at: Date | null;
         created_at: Date;
@@ -127,6 +126,8 @@ The endpoint SHALL call `ctx.success` with:
     }
 }
 ```
+
+The endpoint SHALL NOT return `full_record`. The `full_record` database column SHALL remain the complete immutable upstream snapshot for persistence and forensic recovery. The list query SHALL NOT select the `full_record` column from the database.
 
 ### 5.3 GET /judgement/logs
 


### PR DESCRIPTION
## 概述

本 PR 优化陶片放逐记录接口的响应结构与公开 API 文档，并追加原因、时间范围筛选以及桌面端和移动端界面优化。

## 具体变更

### 精简 Judgement API 响应

- `GET /judgement` 不再返回重复的 `full_record` 字段。
- 列表查询显式选择接口所需字段，不再从数据库读取和解析完整原始快照。
- 数据库中的 `full_record` 列仍保留，用于审计和数据恢复。
- 减少接口响应体积及前端处理复杂度，避免同一数据以多种结构重复返回。

### 完善公开 API 文档

- 根据当前运行环境动态生成公开 API Base URL，不再写死 `https://api.luogu.me/`。
- 在同步日志页面补充记录接口的调用格式、请求示例和查询参数说明。
- 统一查询参数表格与现有数据表格的交互样式。

### 增加记录筛选能力

- 增加“原因”模糊搜索，对 `%`、`_` 和 SQL 转义字符进行字面匹配。
- 增加 `start_time` 与 `end_time`，支持按包含边界的 Unix 秒时间范围查询。
- 支持只指定一侧时间边界，并校验时间范围、数值上限及起止顺序。
- 更新陶片放逐系统规范、后端解析测试和前端查询序列化测试。

### 优化筛选区域

- 字段顺序调整为 UID、用户名、原因、时间段。
- 压缩桌面端基础筛选区域和权限筛选面板。
- 权限的“移除”和“添加”选项采用多列排列，“特殊”选项独立收纳。
- 增加“查看原始页面”按钮，链接至 [洛谷陶片放逐页面](https://www.luogu.com.cn/judgement)。

### 优化移动端布局

- 将筛选操作区整理为规则的双列布局，并修复“查看原始页面”按钮越界。
- 将头像、用户名和 UID 合并到“用户”列。
- 优先展示用户、权限变更等核心信息，减少首屏横向占用。
- 收紧移动端表格单元格间距，并保留横向滚动以查看原因和时间。

## 验证

- 后端 Judgement 单元测试通过。
- 前端查询参数序列化测试通过。
- 后端 TypeScript 构建通过。
- 前端生产构建通过。
- ESLint 检查通过。
- Prettier 格式检查通过。
- `git diff --check` 通过。
