### PR TITLE
修复代码框渲染、钩子尺寸及模态框异常

### DIFF
--- a/packages/frontend/src/components/UserLink.vue
+++ b/packages/frontend/src/components/UserLink.vue
@@ -30,6 +30,7 @@ defineProps<{
             v-if="user && ((user.ccfLevel ?? 0) > 0 || (user.xcpcLevel ?? 0) > 0)"
             :ccf-level="user.ccfLevel ?? 0"
             :xcpc-level="user.xcpcLevel ?? 0"
+            :size="showAvatar ? 16 : 14"
         />
     </div>
 </template>
@@ -38,6 +39,7 @@ defineProps<{
 .user-link-container {
     display: inline-flex;
     align-items: center;
+    gap: 2px;
 }
 .user-name {
     text-decoration: none;

--- a/packages/frontend/src/components/UserPrizeBadge.vue
+++ b/packages/frontend/src/components/UserPrizeBadge.vue
@@ -11,7 +11,7 @@ const props = withDefaults(
     {
         ccfLevel: 0,
         xcpcLevel: 0,
-        size: 20
+        size: 16
     }
 );
 

--- a/packages/frontend/src/styles/global.css
+++ b/packages/frontend/src/styles/global.css
@@ -263,6 +263,18 @@
     color: var(--ui-icon-color) !important;
 }
 
+.n-modal .n-card,
+.n-dialog .n-card {
+    background-color: var(--ui-card-color) !important;
+    color: var(--ui-text-color) !important;
+    border-color: var(--ui-border-color) !important;
+}
+.n-modal .n-card-header__main,
+.n-modal .n-card__content,
+.n-modal .n-card__footer {
+    color: var(--ui-text-color) !important;
+}
+
 .n-alert a {
     color: var(--ui-link-color) !important;
 }

--- a/packages/frontend/src/styles/global.css
+++ b/packages/frontend/src/styles/global.css
@@ -263,15 +263,31 @@
     color: var(--ui-icon-color) !important;
 }
 
+.n-card.n-modal,
 .n-modal .n-card,
 .n-dialog .n-card {
     background-color: var(--ui-card-color) !important;
     color: var(--ui-text-color) !important;
     border-color: var(--ui-border-color) !important;
+    box-shadow: var(--ui-elevated-shadow) !important;
 }
+.n-card.n-modal .n-card-header__main,
+.n-card.n-modal .n-card__content,
+.n-card.n-modal .n-card__footer,
 .n-modal .n-card-header__main,
 .n-modal .n-card__content,
 .n-modal .n-card__footer {
+    color: var(--ui-text-color) !important;
+}
+
+.n-drawer-content-wrapper {
+    background-color: var(--ui-card-color) !important;
+    color: var(--ui-text-color) !important;
+    border-color: var(--ui-border-color) !important;
+}
+.n-drawer-content-wrapper .n-drawer-header,
+.n-drawer-content-wrapper .n-drawer-body-content,
+.n-drawer-content-wrapper .n-drawer-footer {
     color: var(--ui-text-color) !important;
 }
 

--- a/packages/markdown-renderer/src/renderer.ts
+++ b/packages/markdown-renderer/src/renderer.ts
@@ -444,7 +444,7 @@ async function getShikiRuntime() {
             });
             return {
                 highlighter,
-                transform: rehypeShikiModule.default(highlighter, {
+                transform: rehypeShikiModule.default(highlighter as any, {
                     defaultColor: false,
                     themes: { dark: 'github-dark', light: 'github-light' }
                 }) as ShikiTransform
@@ -483,6 +483,27 @@ function loadShikiLanguage(highlighter: HighlighterCore, language: ShikiLanguage
 
 function rehypeLazyShiki() {
     return async (tree: Root) => {
+        // Unlabeled standalone blocks default to C++ for useful syntax coloring.
+        visit(tree, 'element', (node, _index, parent) => {
+            if (
+                node.tagName !== 'code' ||
+                !parent ||
+                parent.type !== 'element' ||
+                parent.tagName !== 'pre'
+            )
+                return;
+            const classes = Array.isArray(node.properties?.className)
+                ? node.properties.className
+                : [];
+            if (
+                !classes.some(value => typeof value === 'string' && value.startsWith('language-'))
+            ) {
+                node.properties = {
+                    ...(node.properties || {}),
+                    className: [...classes, 'language-cpp']
+                };
+            }
+        });
         const requestedLanguages = collectShikiLanguages(tree);
         const languages = new Set<ShikiLanguage>();
         let hasSpecialLanguage = false;

--- a/packages/markdown-renderer/src/renderer.ts
+++ b/packages/markdown-renderer/src/renderer.ts
@@ -482,7 +482,7 @@ function loadShikiLanguage(highlighter: HighlighterCore, language: ShikiLanguage
 }
 
 function rehypeLazyShiki() {
-    return async (tree: Root) => {
+    return async (tree: Root, file: VFile) => {
         // Unlabeled standalone blocks default to C++ for useful syntax coloring.
         visit(tree, 'element', (node, _index, parent) => {
             if (
@@ -492,6 +492,11 @@ function rehypeLazyShiki() {
                 parent.tagName !== 'pre'
             )
                 return;
+            const startLine = node.position?.start.line;
+            const sourceLine = startLine
+                ? String(file.value ?? '').split(/\r?\n/)[startLine - 1]
+                : '';
+            if (/^ {4,}/.test(sourceLine)) return;
             const classes = Array.isArray(node.properties?.className)
                 ? node.properties.className
                 : [];


### PR DESCRIPTION
closes #13 #90

具体效果可以在 <luogu.qzz.io> 查看

1. 代码框如果没有指定代码会渲染异常

原版本
<img width="1018" height="523" alt="image" src="https://github.com/user-attachments/assets/21ed7824-1e13-4cef-a1e6-30101ccee66c" />
修复后
<img width="1034" height="686" alt="image" src="https://github.com/user-attachments/assets/639e73f1-902c-428f-aff9-1aea9cc2bb2f" />

2. https://github.com/laikit-dev/luogu-saver/issues/13 中的钩子大小不合适的相关问题

3. 修复 https://github.com/laikit-dev/luogu-saver/issues/90 中模态框和通知的各种 bug

原版本

<img width="542" height="361" alt="image" src="https://github.com/user-attachments/assets/304516c6-4427-48df-bcd7-f08fa60a7f70" />

<img width="429" height="944" alt="image" src="https://github.com/user-attachments/assets/0745fe9b-6a0c-4da1-b3dd-b66d25b488a3" />

修复后

<img width="535" height="353" alt="image" src="https://github.com/user-attachments/assets/75b818f0-8975-4d57-be7f-bc0c8dcf56d3" />


<img width="425" height="941" alt="image" src="https://github.com/user-attachments/assets/9cc28f77-56e0-461b-9a3c-e2d84a3bc0e6" />

